### PR TITLE
feat:Add custom JSON converter for Unix timestamps and update method signatures

### DIFF
--- a/src/libs/Leonardo/Generated/JsonConverters.UnixTimestamp.g.cs
+++ b/src/libs/Leonardo/Generated/JsonConverters.UnixTimestamp.g.cs
@@ -1,0 +1,39 @@
+#nullable enable
+
+namespace OpenApiGenerator.JsonConverters
+{
+    /// <inheritdoc />
+    public class UnixTimestampJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::System.DateTimeOffset>
+    {
+        /// <inheritdoc />
+        public override global::System.DateTimeOffset Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            if (reader.TokenType == global::System.Text.Json.JsonTokenType.Number)
+            {
+                if (reader.TryGetInt64(out long unixTimestamp))
+                {
+                    return global::System.DateTimeOffset.FromUnixTimeSeconds(unixTimestamp);
+                }
+                if (reader.TryGetInt32(out int unixTimestampInt))
+                {
+                    return global::System.DateTimeOffset.FromUnixTimeSeconds(unixTimestampInt);
+                }
+            }
+
+            return default;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::System.DateTimeOffset value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            long unixTimestamp = value.ToUnixTimeSeconds();
+            writer.WriteNumberValue(unixTimestamp);
+        }
+    }
+}

--- a/src/libs/Leonardo/Generated/Leonardo.ImageClient.GetGenerationsByUserId.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.ImageClient.GetGenerationsByUserId.g.cs
@@ -39,9 +39,9 @@ namespace Leonardo
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         public async global::System.Threading.Tasks.Task<global::Leonardo.GetGenerationsByUserIdResponse> GetGenerationsByUserIdAsync(
-            int offset,
-            int limit,
             string userId,
+            int offset = 0,
+            int limit = 10,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             PrepareArguments(

--- a/src/libs/Leonardo/Generated/Leonardo.TextureClient.GetTextureGenerationById.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.TextureClient.GetTextureGenerationById.g.cs
@@ -42,10 +42,10 @@ namespace Leonardo
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         public async global::System.Threading.Tasks.Task<global::Leonardo.GetTextureGenerationByIdResponse> GetTextureGenerationByIdAsync(
-            int offset,
-            int limit,
             string id,
             global::Leonardo.GetTextureGenerationByIdRequest request,
+            int offset = 0,
+            int limit = 10,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             request = request ?? throw new global::System.ArgumentNullException(nameof(request));

--- a/src/libs/Leonardo/Generated/Leonardo.TextureClient.GetTextureGenerationsByModelId.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.TextureClient.GetTextureGenerationsByModelId.g.cs
@@ -42,10 +42,10 @@ namespace Leonardo
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         public async global::System.Threading.Tasks.Task<global::Leonardo.GetTextureGenerationsByModelIdResponse> GetTextureGenerationsByModelIdAsync(
-            int offset,
-            int limit,
             string modelId,
             global::Leonardo.GetTextureGenerationsByModelIdRequest request,
+            int offset = 0,
+            int limit = 10,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             request = request ?? throw new global::System.ArgumentNullException(nameof(request));

--- a/src/libs/Leonardo/Generated/Leonardo.x3DModelAssetsClient.Get3DModelById.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.x3DModelAssetsClient.Get3DModelById.g.cs
@@ -42,10 +42,10 @@ namespace Leonardo
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         public async global::System.Threading.Tasks.Task<global::Leonardo.Get3DModelByIdResponse> Get3DModelByIdAsync(
-            int offset,
-            int limit,
             string id,
             global::Leonardo.Get3DModelByIdRequest request,
+            int offset = 0,
+            int limit = 10,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             request = request ?? throw new global::System.ArgumentNullException(nameof(request));

--- a/src/libs/Leonardo/Generated/Leonardo.x3DModelAssetsClient.Get3DModelsByUserId.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.x3DModelAssetsClient.Get3DModelsByUserId.g.cs
@@ -42,10 +42,10 @@ namespace Leonardo
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         public async global::System.Threading.Tasks.Task<global::Leonardo.Get3DModelsByUserIdResponse> Get3DModelsByUserIdAsync(
-            int offset,
-            int limit,
             string userId,
             global::Leonardo.Get3DModelsByUserIdRequest request,
+            int offset = 0,
+            int limit = 10,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             request = request ?? throw new global::System.ArgumentNullException(nameof(request));


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a custom JSON converter for Unix timestamps, enhancing the serialization and deserialization of `DateTimeOffset` objects.
  - Updated several methods to allow optional parameters for `offset` and `limit`, simplifying method calls for retrieving generations and models.

- **Bug Fixes**
  - Ensured that methods still function correctly with new default parameter values while maintaining existing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->