### PR TITLE
feat:Update upscaleMultiplier defaults for Universal and Ultra services

### DIFF
--- a/src/libs/Leonardo/Generated/Leonardo.IVariationClient.CreateUniversalUpscalerJob.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.IVariationClient.CreateUniversalUpscalerJob.g.cs
@@ -42,7 +42,8 @@ namespace Leonardo
         /// The ultra style to upscale images using universal upscaler with. Can not be used with upscalerStyle.
         /// </param>
         /// <param name="upscaleMultiplier">
-        /// The upscale multiplier of the universal upscaler. Must be between 1.0 and 2.0.
+        /// The upscale multiplier of the universal upscaler. Must be between 1.0 and 2.0.<br/>
+        /// Default Value: 1.5
         /// </param>
         /// <param name="upscalerStyle">
         /// The style to upscale images using universal upscaler with. Can not be used with ultraUpscaleStyle.<br/>

--- a/src/libs/Leonardo/Generated/Leonardo.Models.CreateUniversalUpscalerJobRequest.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.CreateUniversalUpscalerJobRequest.g.cs
@@ -53,7 +53,8 @@ namespace Leonardo
         public global::Leonardo.UniversalUpscalerUltraStyle? UltraUpscaleStyle { get; set; }
 
         /// <summary>
-        /// The upscale multiplier of the universal upscaler. Must be between 1.0 and 2.0.
+        /// The upscale multiplier of the universal upscaler. Must be between 1.0 and 2.0.<br/>
+        /// Default Value: 1.5
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("upscaleMultiplier")]
         public double? UpscaleMultiplier { get; set; }
@@ -104,7 +105,8 @@ namespace Leonardo
         /// The ultra style to upscale images using universal upscaler with. Can not be used with upscalerStyle.
         /// </param>
         /// <param name="upscaleMultiplier">
-        /// The upscale multiplier of the universal upscaler. Must be between 1.0 and 2.0.
+        /// The upscale multiplier of the universal upscaler. Must be between 1.0 and 2.0.<br/>
+        /// Default Value: 1.5
         /// </param>
         /// <param name="upscalerStyle">
         /// The style to upscale images using universal upscaler with. Can not be used with ultraUpscaleStyle.<br/>

--- a/src/libs/Leonardo/Generated/Leonardo.Models.PricingCalculatorRequestServiceParamsUNIVERSALUPSCALERULTRA.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.PricingCalculatorRequestServiceParamsUNIVERSALUPSCALERULTRA.g.cs
@@ -21,8 +21,7 @@ namespace Leonardo
         public int? InputHeight { get; set; }
 
         /// <summary>
-        /// The upscale multiplier of the universal upscaler. Must be between 1.00 and 2.00.<br/>
-        /// Default Value: 1.5
+        /// The upscale multiplier of the universal upscaler. Must be between 1.00 and 2.00.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("upscaleMultiplier")]
         public double? UpscaleMultiplier { get; set; }
@@ -43,8 +42,7 @@ namespace Leonardo
         /// The input height of the image.
         /// </param>
         /// <param name="upscaleMultiplier">
-        /// The upscale multiplier of the universal upscaler. Must be between 1.00 and 2.00.<br/>
-        /// Default Value: 1.5
+        /// The upscale multiplier of the universal upscaler. Must be between 1.00 and 2.00.
         /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]

--- a/src/libs/Leonardo/Generated/Leonardo.VariationClient.CreateUniversalUpscalerJob.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.VariationClient.CreateUniversalUpscalerJob.g.cs
@@ -193,7 +193,8 @@ namespace Leonardo
         /// The ultra style to upscale images using universal upscaler with. Can not be used with upscalerStyle.
         /// </param>
         /// <param name="upscaleMultiplier">
-        /// The upscale multiplier of the universal upscaler. Must be between 1.0 and 2.0.
+        /// The upscale multiplier of the universal upscaler. Must be between 1.0 and 2.0.<br/>
+        /// Default Value: 1.5
         /// </param>
         /// <param name="upscalerStyle">
         /// The style to upscale images using universal upscaler with. Can not be used with ultraUpscaleStyle.<br/>

--- a/src/libs/Leonardo/openapi.yaml
+++ b/src/libs/Leonardo/openapi.yaml
@@ -1928,6 +1928,7 @@ paths:
                   title: Float
                   type: number
                   description: The upscale multiplier of the universal upscaler. Must be between 1.0 and 2.0.
+                  default: 1.5
                   nullable: true
                 upscalerStyle:
                   $ref: '#/components/schemas/universal_upscaler_style'
@@ -3073,7 +3074,6 @@ paths:
                           title: Float
                           type: number
                           description: The upscale multiplier of the universal upscaler. Must be between 1.00 and 2.00.
-                          default: 1.5
                       description: Parameters for UNIVERSAL_UPSCALER_ULTRA service
                       nullable: true
                   description: Parameters for the service


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The Universal Upscaler now applies a default upscale multiplier of 1.5 when no value is provided.
  - The Universal Upscaler Ultra has been updated to require users to explicitly set the upscale multiplier, as the default has been removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->