### PR TITLE
feat:Add VEO3_MOTION_VIDEO_GENERATION service type with 720p resolution schema

### DIFF
--- a/src/libs/Leonardo/Generated/Leonardo..JsonSerializerContext.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo..JsonSerializerContext.g.cs
@@ -65,6 +65,8 @@ namespace Leonardo
             typeof(global::Leonardo.JsonConverters.CreateModelRequestSdVersionNullableJsonConverter),
             typeof(global::Leonardo.JsonConverters.CreateElementRequestSdVersionJsonConverter),
             typeof(global::Leonardo.JsonConverters.CreateElementRequestSdVersionNullableJsonConverter),
+            typeof(global::Leonardo.JsonConverters.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolutionJsonConverter),
+            typeof(global::Leonardo.JsonConverters.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolutionNullableJsonConverter),
             typeof(global::Leonardo.JsonConverters.PricingCalculatorRequestServiceParamsMODELTRAININGSdVersionJsonConverter),
             typeof(global::Leonardo.JsonConverters.PricingCalculatorRequestServiceParamsMODELTRAININGSdVersionNullableJsonConverter),
             typeof(global::Leonardo.JsonConverters.UnixTimestampJsonConverter),

--- a/src/libs/Leonardo/Generated/Leonardo.JsonConverters.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.JsonConverters.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution.g.cs
@@ -1,0 +1,53 @@
+#nullable enable
+
+namespace Leonardo.JsonConverters
+{
+    /// <inheritdoc />
+    public sealed class PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolutionJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution>
+    {
+        /// <inheritdoc />
+        public override global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case global::System.Text.Json.JsonTokenType.String:
+                {
+                    var stringValue = reader.GetString();
+                    if (stringValue != null)
+                    {
+                        return global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolutionExtensions.ToEnum(stringValue) ?? default;
+                    }
+                    
+                    break;
+                }
+                case global::System.Text.Json.JsonTokenType.Number:
+                {
+                    var numValue = reader.GetInt32();
+                    return (global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution)numValue;
+                }
+                case global::System.Text.Json.JsonTokenType.Null:
+                {
+                    return default(global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution);
+                }
+                default:
+                    throw new global::System.ArgumentOutOfRangeException(nameof(reader));
+            }
+
+            return default;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            writer = writer ?? throw new global::System.ArgumentNullException(nameof(writer));
+
+            writer.WriteStringValue(global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolutionExtensions.ToValueString(value));
+        }
+    }
+}

--- a/src/libs/Leonardo/Generated/Leonardo.JsonConverters.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolutionNullable.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.JsonConverters.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolutionNullable.g.cs
@@ -1,0 +1,60 @@
+#nullable enable
+
+namespace Leonardo.JsonConverters
+{
+    /// <inheritdoc />
+    public sealed class PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolutionNullableJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution?>
+    {
+        /// <inheritdoc />
+        public override global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution? Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case global::System.Text.Json.JsonTokenType.String:
+                {
+                    var stringValue = reader.GetString();
+                    if (stringValue != null)
+                    {
+                        return global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolutionExtensions.ToEnum(stringValue);
+                    }
+                    
+                    break;
+                }
+                case global::System.Text.Json.JsonTokenType.Number:
+                {
+                    var numValue = reader.GetInt32();
+                    return (global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution)numValue;
+                }
+                case global::System.Text.Json.JsonTokenType.Null:
+                {
+                    return default(global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution?);
+                }
+                default:
+                    throw new global::System.ArgumentOutOfRangeException(nameof(reader));
+            }
+
+            return default;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution? value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            writer = writer ?? throw new global::System.ArgumentNullException(nameof(writer));
+
+            if (value == null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteStringValue(global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolutionExtensions.ToValueString(value.Value));
+            }
+        }
+    }
+}

--- a/src/libs/Leonardo/Generated/Leonardo.JsonSerializerContextTypes.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.JsonSerializerContextTypes.g.cs
@@ -318,546 +318,554 @@ namespace Leonardo
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequestServiceParamsLCMGENERATION? Type73 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION? Type73 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequestServiceParamsMODELTRAINING? Type74 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution? Type74 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequestServiceParamsMODELTRAININGSdVersion? Type75 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsLCMGENERATION? Type75 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequestServiceParamsTEXTUREGENERATION? Type76 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsMODELTRAINING? Type76 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequestServiceParamsUNIVERSALUPSCALER? Type77 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsMODELTRAININGSdVersion? Type77 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequestServiceParamsUNIVERSALUPSCALERULTRA? Type78 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsTEXTUREGENERATION? Type78 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetUserSelfResponse? Type79 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsUNIVERSALUPSCALER? Type79 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetUserSelfResponseUserDetail>? Type80 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsUNIVERSALUPSCALERULTRA? Type80 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetUserSelfResponseUserDetail? Type81 { get; set; }
+        public global::Leonardo.GetUserSelfResponse? Type81 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetUserSelfResponseUserDetailUser? Type82 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetUserSelfResponseUserDetail>? Type82 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateGenerationResponse? Type83 { get; set; }
+        public global::Leonardo.GetUserSelfResponseUserDetail? Type83 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateGenerationResponseSdGenerationJob? Type84 { get; set; }
+        public global::Leonardo.GetUserSelfResponseUserDetailUser? Type84 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationByIdResponse? Type85 { get; set; }
+        public global::Leonardo.CreateGenerationResponse? Type85 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationByIdResponseGenerationsByPk? Type86 { get; set; }
+        public global::Leonardo.CreateGenerationResponseSdGenerationJob? Type86 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationByIdResponseGenerationsByPkGeneratedImage>? Type87 { get; set; }
+        public global::Leonardo.GetGenerationByIdResponse? Type87 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationByIdResponseGenerationsByPkGeneratedImage? Type88 { get; set; }
+        public global::Leonardo.GetGenerationByIdResponseGenerationsByPk? Type88 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationByIdResponseGenerationsByPkGeneratedImageGeneratedImageVariationGeneric>? Type89 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationByIdResponseGenerationsByPkGeneratedImage>? Type89 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationByIdResponseGenerationsByPkGeneratedImageGeneratedImageVariationGeneric? Type90 { get; set; }
+        public global::Leonardo.GetGenerationByIdResponseGenerationsByPkGeneratedImage? Type90 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationByIdResponseGenerationsByPkGenerationElement>? Type91 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationByIdResponseGenerationsByPkGeneratedImageGeneratedImageVariationGeneric>? Type91 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationByIdResponseGenerationsByPkGenerationElement? Type92 { get; set; }
+        public global::Leonardo.GetGenerationByIdResponseGenerationsByPkGeneratedImageGeneratedImageVariationGeneric? Type92 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationByIdResponseGenerationsByPkGenerationElementLora? Type93 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationByIdResponseGenerationsByPkGenerationElement>? Type93 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteGenerationByIdResponse? Type94 { get; set; }
+        public global::Leonardo.GetGenerationByIdResponseGenerationsByPkGenerationElement? Type94 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteGenerationByIdResponseDeleteGenerationsByPk? Type95 { get; set; }
+        public global::Leonardo.GetGenerationByIdResponseGenerationsByPkGenerationElementLora? Type95 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationsByUserIdResponse? Type96 { get; set; }
+        public global::Leonardo.DeleteGenerationByIdResponse? Type96 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationsByUserIdResponseGeneration>? Type97 { get; set; }
+        public global::Leonardo.DeleteGenerationByIdResponseDeleteGenerationsByPk? Type97 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationsByUserIdResponseGeneration? Type98 { get; set; }
+        public global::Leonardo.GetGenerationsByUserIdResponse? Type98 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationsByUserIdResponseGenerationGeneratedImage>? Type99 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationsByUserIdResponseGeneration>? Type99 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationsByUserIdResponseGenerationGeneratedImage? Type100 { get; set; }
+        public global::Leonardo.GetGenerationsByUserIdResponseGeneration? Type100 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationsByUserIdResponseGenerationGeneratedImageGeneratedImageVariationGeneric>? Type101 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationsByUserIdResponseGenerationGeneratedImage>? Type101 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationsByUserIdResponseGenerationGeneratedImageGeneratedImageVariationGeneric? Type102 { get; set; }
+        public global::Leonardo.GetGenerationsByUserIdResponseGenerationGeneratedImage? Type102 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationsByUserIdResponseGenerationGenerationElement>? Type103 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationsByUserIdResponseGenerationGeneratedImageGeneratedImageVariationGeneric>? Type103 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationsByUserIdResponseGenerationGenerationElement? Type104 { get; set; }
+        public global::Leonardo.GetGenerationsByUserIdResponseGenerationGeneratedImageGeneratedImageVariationGeneric? Type104 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationsByUserIdResponseGenerationGenerationElementLora? Type105 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationsByUserIdResponseGenerationGenerationElement>? Type105 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateTextureGenerationResponse? Type106 { get; set; }
+        public global::Leonardo.GetGenerationsByUserIdResponseGenerationGenerationElement? Type106 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateTextureGenerationResponseTextureGenerationJob? Type107 { get; set; }
+        public global::Leonardo.GetGenerationsByUserIdResponseGenerationGenerationElementLora? Type107 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateSVDMotionGenerationResponse? Type108 { get; set; }
+        public global::Leonardo.CreateTextureGenerationResponse? Type108 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateSVDMotionGenerationResponseMotionSvdGenerationJob? Type109 { get; set; }
+        public global::Leonardo.CreateTextureGenerationResponseTextureGenerationJob? Type109 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateImageToVideoGenerationResponse? Type110 { get; set; }
+        public global::Leonardo.CreateSVDMotionGenerationResponse? Type110 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateImageToVideoGenerationResponseMotionVideoGenerationJob? Type111 { get; set; }
+        public global::Leonardo.CreateSVDMotionGenerationResponseMotionSvdGenerationJob? Type111 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateTextToVideoGenerationResponse? Type112 { get; set; }
+        public global::Leonardo.CreateImageToVideoGenerationResponse? Type112 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateTextToVideoGenerationResponseMotionVideoGenerationJob? Type113 { get; set; }
+        public global::Leonardo.CreateImageToVideoGenerationResponseMotionVideoGenerationJob? Type113 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVideoUpscaleResponse? Type114 { get; set; }
+        public global::Leonardo.CreateTextToVideoGenerationResponse? Type114 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVideoUpscaleResponseMotionVideoGenerationJob? Type115 { get; set; }
+        public global::Leonardo.CreateTextToVideoGenerationResponseMotionVideoGenerationJob? Type115 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateLCMGenerationResponse? Type116 { get; set; }
+        public global::Leonardo.CreateVideoUpscaleResponse? Type116 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateLCMGenerationResponseLcmGenerationJob? Type117 { get; set; }
+        public global::Leonardo.CreateVideoUpscaleResponseMotionVideoGenerationJob? Type117 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PerformInstantRefineResponse? Type118 { get; set; }
+        public global::Leonardo.CreateLCMGenerationResponse? Type118 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PerformInstantRefineResponseLcmGenerationJob? Type119 { get; set; }
+        public global::Leonardo.CreateLCMGenerationResponseLcmGenerationJob? Type119 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PerformInpaintingLCMResponse? Type120 { get; set; }
+        public global::Leonardo.PerformInstantRefineResponse? Type120 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PerformInpaintingLCMResponseLcmGenerationJob? Type121 { get; set; }
+        public global::Leonardo.PerformInstantRefineResponseLcmGenerationJob? Type121 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PerformAlchemyUpscaleLCMResponse? Type122 { get; set; }
+        public global::Leonardo.PerformInpaintingLCMResponse? Type122 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PerformAlchemyUpscaleLCMResponseLcmGenerationJob? Type123 { get; set; }
+        public global::Leonardo.PerformInpaintingLCMResponseLcmGenerationJob? Type123 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetTextureGenerationsByModelIdResponse? Type124 { get; set; }
+        public global::Leonardo.PerformAlchemyUpscaleLCMResponse? Type124 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetTextureGenerationsByModelIdResponseModelAssetTextureGeneration>? Type125 { get; set; }
+        public global::Leonardo.PerformAlchemyUpscaleLCMResponseLcmGenerationJob? Type125 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetTextureGenerationsByModelIdResponseModelAssetTextureGeneration? Type126 { get; set; }
+        public global::Leonardo.GetTextureGenerationsByModelIdResponse? Type126 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetTextureGenerationsByModelIdResponseModelAssetTextureGenerationModelAssetTextureImage>? Type127 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetTextureGenerationsByModelIdResponseModelAssetTextureGeneration>? Type127 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetTextureGenerationsByModelIdResponseModelAssetTextureGenerationModelAssetTextureImage? Type128 { get; set; }
+        public global::Leonardo.GetTextureGenerationsByModelIdResponseModelAssetTextureGeneration? Type128 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetTextureGenerationByIdResponse? Type129 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetTextureGenerationsByModelIdResponseModelAssetTextureGenerationModelAssetTextureImage>? Type129 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetTextureGenerationByIdResponseModelAssetTextureGenerationsByPk? Type130 { get; set; }
+        public global::Leonardo.GetTextureGenerationsByModelIdResponseModelAssetTextureGenerationModelAssetTextureImage? Type130 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetTextureGenerationByIdResponseModelAssetTextureGenerationsByPkModelAssetTextureImage>? Type131 { get; set; }
+        public global::Leonardo.GetTextureGenerationByIdResponse? Type131 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetTextureGenerationByIdResponseModelAssetTextureGenerationsByPkModelAssetTextureImage? Type132 { get; set; }
+        public global::Leonardo.GetTextureGenerationByIdResponseModelAssetTextureGenerationsByPk? Type132 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteTextureGenerationByIdResponse? Type133 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetTextureGenerationByIdResponseModelAssetTextureGenerationsByPkModelAssetTextureImage>? Type133 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteTextureGenerationByIdResponseDeleteModelAssetTextureGenerationsByPk? Type134 { get; set; }
+        public global::Leonardo.GetTextureGenerationByIdResponseModelAssetTextureGenerationsByPkModelAssetTextureImage? Type134 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadModelAssetResponse? Type135 { get; set; }
+        public global::Leonardo.DeleteTextureGenerationByIdResponse? Type135 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadModelAssetResponseUploadModelAsset? Type136 { get; set; }
+        public global::Leonardo.DeleteTextureGenerationByIdResponseDeleteModelAssetTextureGenerationsByPk? Type136 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.Get3DModelsByUserIdResponse? Type137 { get; set; }
+        public global::Leonardo.UploadModelAssetResponse? Type137 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.Get3DModelsByUserIdResponseModelAsset>? Type138 { get; set; }
+        public global::Leonardo.UploadModelAssetResponseUploadModelAsset? Type138 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.Get3DModelsByUserIdResponseModelAsset? Type139 { get; set; }
+        public global::Leonardo.Get3DModelsByUserIdResponse? Type139 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.Get3DModelByIdResponse? Type140 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.Get3DModelsByUserIdResponseModelAsset>? Type140 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.Get3DModelByIdResponseModelAssetsByPk? Type141 { get; set; }
+        public global::Leonardo.Get3DModelsByUserIdResponseModelAsset? Type141 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.Delete3DModelByIdResponse? Type142 { get; set; }
+        public global::Leonardo.Get3DModelByIdResponse? Type142 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.Delete3DModelByIdResponseDeleteModelAssetsByPk? Type143 { get; set; }
+        public global::Leonardo.Get3DModelByIdResponseModelAssetsByPk? Type143 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadInitImageResponse? Type144 { get; set; }
+        public global::Leonardo.Delete3DModelByIdResponse? Type144 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadInitImageResponseUploadInitImage? Type145 { get; set; }
+        public global::Leonardo.Delete3DModelByIdResponseDeleteModelAssetsByPk? Type145 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetInitImageByIdResponse? Type146 { get; set; }
+        public global::Leonardo.UploadInitImageResponse? Type146 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetInitImageByIdResponseInitImagesByPk? Type147 { get; set; }
+        public global::Leonardo.UploadInitImageResponseUploadInitImage? Type147 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteInitImageByIdResponse? Type148 { get; set; }
+        public global::Leonardo.GetInitImageByIdResponse? Type148 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteInitImageByIdResponseDeleteInitImagesByPk? Type149 { get; set; }
+        public global::Leonardo.GetInitImageByIdResponseInitImagesByPk? Type149 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadCanvasInitImageResponse? Type150 { get; set; }
+        public global::Leonardo.DeleteInitImageByIdResponse? Type150 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadCanvasInitImageResponseUploadCanvasInitImage? Type151 { get; set; }
+        public global::Leonardo.DeleteInitImageByIdResponseDeleteInitImagesByPk? Type151 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVariationUnzoomResponse? Type152 { get; set; }
+        public global::Leonardo.UploadCanvasInitImageResponse? Type152 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVariationUnzoomResponseSdUnzoomJob? Type153 { get; set; }
+        public global::Leonardo.UploadCanvasInitImageResponseUploadCanvasInitImage? Type153 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVariationUpscaleResponse? Type154 { get; set; }
+        public global::Leonardo.CreateVariationUnzoomResponse? Type154 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVariationUpscaleResponseSdUpscaleJob? Type155 { get; set; }
+        public global::Leonardo.CreateVariationUnzoomResponseSdUnzoomJob? Type155 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVariationNoBGResponse? Type156 { get; set; }
+        public global::Leonardo.CreateVariationUpscaleResponse? Type156 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVariationNoBGResponseSdNobgJob? Type157 { get; set; }
+        public global::Leonardo.CreateVariationUpscaleResponseSdUpscaleJob? Type157 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateUniversalUpscalerJobResponse? Type158 { get; set; }
+        public global::Leonardo.CreateVariationNoBGResponse? Type158 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateUniversalUpscalerJobResponseUniversalUpscaler? Type159 { get; set; }
+        public global::Leonardo.CreateVariationNoBGResponseSdNobgJob? Type159 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetVariationByIdResponse? Type160 { get; set; }
+        public global::Leonardo.CreateUniversalUpscalerJobResponse? Type160 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetVariationByIdResponseGeneratedImageVariationGenericItem>? Type161 { get; set; }
+        public global::Leonardo.CreateUniversalUpscalerJobResponseUniversalUpscaler? Type161 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetVariationByIdResponseGeneratedImageVariationGenericItem? Type162 { get; set; }
+        public global::Leonardo.GetVariationByIdResponse? Type162 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetMotionVariationByIdResponse? Type163 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetVariationByIdResponseGeneratedImageVariationGenericItem>? Type163 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetMotionVariationByIdResponseGeneratedImageVariationMotionItem>? Type164 { get; set; }
+        public global::Leonardo.GetVariationByIdResponseGeneratedImageVariationGenericItem? Type164 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetMotionVariationByIdResponseGeneratedImageVariationMotionItem? Type165 { get; set; }
+        public global::Leonardo.GetMotionVariationByIdResponse? Type165 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateDatasetResponse? Type166 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetMotionVariationByIdResponseGeneratedImageVariationMotionItem>? Type166 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateDatasetResponseInsertDatasetsOne? Type167 { get; set; }
+        public global::Leonardo.GetMotionVariationByIdResponseGeneratedImageVariationMotionItem? Type167 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetDatasetByIdResponse? Type168 { get; set; }
+        public global::Leonardo.CreateDatasetResponse? Type168 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetDatasetByIdResponseDatasetsByPk? Type169 { get; set; }
+        public global::Leonardo.CreateDatasetResponseInsertDatasetsOne? Type169 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetDatasetByIdResponseDatasetsByPkDatasetImage>? Type170 { get; set; }
+        public global::Leonardo.GetDatasetByIdResponse? Type170 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetDatasetByIdResponseDatasetsByPkDatasetImage? Type171 { get; set; }
+        public global::Leonardo.GetDatasetByIdResponseDatasetsByPk? Type171 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteDatasetByIdResponse? Type172 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetDatasetByIdResponseDatasetsByPkDatasetImage>? Type172 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteDatasetByIdResponseDeleteDatasetsByPk? Type173 { get; set; }
+        public global::Leonardo.GetDatasetByIdResponseDatasetsByPkDatasetImage? Type173 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadDatasetImageResponse? Type174 { get; set; }
+        public global::Leonardo.DeleteDatasetByIdResponse? Type174 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadDatasetImageResponseUploadDatasetImage? Type175 { get; set; }
+        public global::Leonardo.DeleteDatasetByIdResponseDeleteDatasetsByPk? Type175 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadDatasetImageFromGenResponse? Type176 { get; set; }
+        public global::Leonardo.UploadDatasetImageResponse? Type176 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadDatasetImageFromGenResponseUploadDatasetImageFromGen? Type177 { get; set; }
+        public global::Leonardo.UploadDatasetImageResponseUploadDatasetImage? Type177 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateModelResponse? Type178 { get; set; }
+        public global::Leonardo.UploadDatasetImageFromGenResponse? Type178 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateModelResponseSdTrainingJob? Type179 { get; set; }
+        public global::Leonardo.UploadDatasetImageFromGenResponseUploadDatasetImageFromGen? Type179 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetModelByIdResponse? Type180 { get; set; }
+        public global::Leonardo.CreateModelResponse? Type180 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetModelByIdResponseCustomModelsByPk? Type181 { get; set; }
+        public global::Leonardo.CreateModelResponseSdTrainingJob? Type181 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteModelByIdResponse? Type182 { get; set; }
+        public global::Leonardo.GetModelByIdResponse? Type182 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteModelByIdResponseDeleteCustomModelsByPk? Type183 { get; set; }
+        public global::Leonardo.GetModelByIdResponseCustomModelsByPk? Type183 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetCustomModelsByUserIdResponse? Type184 { get; set; }
+        public global::Leonardo.DeleteModelByIdResponse? Type184 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetCustomModelsByUserIdResponseCustomModel>? Type185 { get; set; }
+        public global::Leonardo.DeleteModelByIdResponseDeleteCustomModelsByPk? Type185 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetCustomModelsByUserIdResponseCustomModel? Type186 { get; set; }
+        public global::Leonardo.GetCustomModelsByUserIdResponse? Type186 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.ListPlatformModelsResponse? Type187 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetCustomModelsByUserIdResponseCustomModel>? Type187 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.ListPlatformModelsResponseCustomModel>? Type188 { get; set; }
+        public global::Leonardo.GetCustomModelsByUserIdResponseCustomModel? Type188 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.ListPlatformModelsResponseCustomModel? Type189 { get; set; }
+        public global::Leonardo.ListPlatformModelsResponse? Type189 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.ListPlatformModelsResponseCustomModelGeneratedImage? Type190 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.ListPlatformModelsResponseCustomModel>? Type190 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetElementByIdResponse? Type191 { get; set; }
+        public global::Leonardo.ListPlatformModelsResponseCustomModel? Type191 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetElementByIdResponseUserLorasByPk? Type192 { get; set; }
+        public global::Leonardo.ListPlatformModelsResponseCustomModelGeneratedImage? Type192 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteElementByIdResponse? Type193 { get; set; }
+        public global::Leonardo.GetElementByIdResponse? Type193 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteElementByIdResponseDeleteUserLorasByPk? Type194 { get; set; }
+        public global::Leonardo.GetElementByIdResponseUserLorasByPk? Type194 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetCustomElementsByUserIdResponse? Type195 { get; set; }
+        public global::Leonardo.DeleteElementByIdResponse? Type195 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetCustomElementsByUserIdResponseUserLora>? Type196 { get; set; }
+        public global::Leonardo.DeleteElementByIdResponseDeleteUserLorasByPk? Type196 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetCustomElementsByUserIdResponseUserLora? Type197 { get; set; }
+        public global::Leonardo.GetCustomElementsByUserIdResponse? Type197 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateElementResponse? Type198 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetCustomElementsByUserIdResponseUserLora>? Type198 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateElementResponseSdTrainingJob? Type199 { get; set; }
+        public global::Leonardo.GetCustomElementsByUserIdResponseUserLora? Type199 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.ListElementsResponse? Type200 { get; set; }
+        public global::Leonardo.CreateElementResponse? Type200 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.ListElementsResponseLora>? Type201 { get; set; }
+        public global::Leonardo.CreateElementResponseSdTrainingJob? Type201 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.ListElementsResponseLora? Type202 { get; set; }
+        public global::Leonardo.ListElementsResponse? Type202 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PromptRandomResponse? Type203 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.ListElementsResponseLora>? Type203 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PromptRandomResponsePromptGeneration? Type204 { get; set; }
+        public global::Leonardo.ListElementsResponseLora? Type204 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PromptImproveResponse? Type205 { get; set; }
+        public global::Leonardo.PromptRandomResponse? Type205 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PromptImproveResponsePromptGeneration? Type206 { get; set; }
+        public global::Leonardo.PromptRandomResponsePromptGeneration? Type206 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorResponse? Type207 { get; set; }
+        public global::Leonardo.PromptImproveResponse? Type207 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorResponseCalculateProductionApiServiceCost? Type208 { get; set; }
+        public global::Leonardo.PromptImproveResponsePromptGeneration? Type208 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::Leonardo.PricingCalculatorResponse? Type209 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::Leonardo.PricingCalculatorResponseCalculateProductionApiServiceCost? Type210 { get; set; }
     }
 }

--- a/src/libs/Leonardo/Generated/Leonardo.Models.PricingCalculatorRequestServiceParams.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.PricingCalculatorRequestServiceParams.g.cs
@@ -33,6 +33,12 @@ namespace Leonardo
         public global::Leonardo.PricingCalculatorRequestServiceParamsMOTIONVIDEOGENERATION? MOTIONVIDEOGENERATION { get; set; }
 
         /// <summary>
+        /// Parameters for VEO3_MOTION_VIDEO_GENERATION service
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("VEO3_MOTION_VIDEO_GENERATION")]
+        public global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION? VEO3MOTIONVIDEOGENERATION { get; set; }
+
+        /// <summary>
         /// Parameters for LCM_GENERATION service
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("LCM_GENERATION")]
@@ -83,6 +89,9 @@ namespace Leonardo
         /// <param name="mOTIONVIDEOGENERATION">
         /// Parameters for MOTION_VIDEO_GENERATION service
         /// </param>
+        /// <param name="vEO3MOTIONVIDEOGENERATION">
+        /// Parameters for VEO3_MOTION_VIDEO_GENERATION service
+        /// </param>
         /// <param name="lCMGENERATION">
         /// Parameters for LCM_GENERATION service
         /// </param>
@@ -106,6 +115,7 @@ namespace Leonardo
             global::Leonardo.PricingCalculatorRequestServiceParamsFANTASYAVATARGENERATION? fANTASYAVATARGENERATION,
             object? mOTIONSVDGENERATION,
             global::Leonardo.PricingCalculatorRequestServiceParamsMOTIONVIDEOGENERATION? mOTIONVIDEOGENERATION,
+            global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION? vEO3MOTIONVIDEOGENERATION,
             global::Leonardo.PricingCalculatorRequestServiceParamsLCMGENERATION? lCMGENERATION,
             global::Leonardo.PricingCalculatorRequestServiceParamsMODELTRAINING? mODELTRAINING,
             global::Leonardo.PricingCalculatorRequestServiceParamsTEXTUREGENERATION? tEXTUREGENERATION,
@@ -116,6 +126,7 @@ namespace Leonardo
             this.FANTASYAVATARGENERATION = fANTASYAVATARGENERATION;
             this.MOTIONSVDGENERATION = mOTIONSVDGENERATION;
             this.MOTIONVIDEOGENERATION = mOTIONVIDEOGENERATION;
+            this.VEO3MOTIONVIDEOGENERATION = vEO3MOTIONVIDEOGENERATION;
             this.LCMGENERATION = lCMGENERATION;
             this.MODELTRAINING = mODELTRAINING;
             this.TEXTUREGENERATION = tEXTUREGENERATION;

--- a/src/libs/Leonardo/Generated/Leonardo.Models.PricingCalculatorRequestServiceParamsMOTIONVIDEOGENERATION.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.PricingCalculatorRequestServiceParamsMOTIONVIDEOGENERATION.g.cs
@@ -9,7 +9,7 @@ namespace Leonardo
     public sealed partial class PricingCalculatorRequestServiceParamsMOTIONVIDEOGENERATION
     {
         /// <summary>
-        /// The resolution of the video. Must be enum value of FAST and QUALITY.
+        /// The resolution of the video. Must be RESOLUTION_480 or RESOLUTION_720.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("resolution")]
         public string? Resolution { get; set; }
@@ -24,7 +24,7 @@ namespace Leonardo
         /// Initializes a new instance of the <see cref="PricingCalculatorRequestServiceParamsMOTIONVIDEOGENERATION" /> class.
         /// </summary>
         /// <param name="resolution">
-        /// The resolution of the video. Must be enum value of FAST and QUALITY.
+        /// The resolution of the video. Must be RESOLUTION_480 or RESOLUTION_720.
         /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]

--- a/src/libs/Leonardo/Generated/Leonardo.Models.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION.Json.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION.Json.g.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+namespace Leonardo
+{
+    public sealed partial class PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION
+    {
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public string ToJson(
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                this.GetType(),
+                jsonSerializerContext);
+        }
+
+        /// <summary>
+        /// Serializes the current instance to a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public string ToJson(
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Serialize(
+                this,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerContext.
+        /// </summary>
+        public static global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION? FromJson(
+            string json,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize(
+                json,
+                typeof(global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION),
+                jsonSerializerContext) as global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON string using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION? FromJson(
+            string json,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.Deserialize<global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION>(
+                json,
+                jsonSerializerOptions);
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerContext.
+        /// </summary>
+        public static async global::System.Threading.Tasks.ValueTask<global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.Serialization.JsonSerializerContext jsonSerializerContext)
+        {
+            return (await global::System.Text.Json.JsonSerializer.DeserializeAsync(
+                jsonStream,
+                typeof(global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION),
+                jsonSerializerContext).ConfigureAwait(false)) as global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION;
+        }
+
+        /// <summary>
+        /// Deserializes a JSON stream using the provided JsonSerializerOptions.
+        /// </summary>
+#if NET8_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")]
+        [global::System.Diagnostics.CodeAnalysis.RequiresDynamicCode("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.")]
+#endif
+        public static global::System.Threading.Tasks.ValueTask<global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION?> FromJsonStreamAsync(
+            global::System.IO.Stream jsonStream,
+            global::System.Text.Json.JsonSerializerOptions? jsonSerializerOptions = null)
+        {
+            return global::System.Text.Json.JsonSerializer.DeserializeAsync<global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION?>(
+                jsonStream,
+                jsonSerializerOptions);
+        }
+    }
+}

--- a/src/libs/Leonardo/Generated/Leonardo.Models.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION.g.cs
@@ -1,0 +1,46 @@
+
+#nullable enable
+
+namespace Leonardo
+{
+    /// <summary>
+    /// Parameters for VEO3_MOTION_VIDEO_GENERATION service
+    /// </summary>
+    public sealed partial class PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION
+    {
+        /// <summary>
+        /// The resolution of the video. Supported resolution for VEO3 is RESOLUTION_720.
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("resolution")]
+        [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Leonardo.JsonConverters.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolutionJsonConverter))]
+        public global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution? Resolution { get; set; }
+
+        /// <summary>
+        /// Additional properties that are not explicitly defined in the schema
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonExtensionData]
+        public global::System.Collections.Generic.IDictionary<string, object> AdditionalProperties { get; set; } = new global::System.Collections.Generic.Dictionary<string, object>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION" /> class.
+        /// </summary>
+        /// <param name="resolution">
+        /// The resolution of the video. Supported resolution for VEO3 is RESOLUTION_720.
+        /// </param>
+#if NET7_0_OR_GREATER
+        [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
+#endif
+        public PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION(
+            global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution? resolution)
+        {
+            this.Resolution = resolution;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION" /> class.
+        /// </summary>
+        public PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION()
+        {
+        }
+    }
+}

--- a/src/libs/Leonardo/Generated/Leonardo.Models.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution.g.cs
@@ -1,0 +1,45 @@
+
+#nullable enable
+
+namespace Leonardo
+{
+    /// <summary>
+    /// The resolution of the video. Supported resolution for VEO3 is RESOLUTION_720.
+    /// </summary>
+    public enum PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        RESOLUTION720,
+    }
+
+    /// <summary>
+    /// Enum extensions to do fast conversions without the reflection.
+    /// </summary>
+    public static class PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolutionExtensions
+    {
+        /// <summary>
+        /// Converts an enum to a string.
+        /// </summary>
+        public static string ToValueString(this PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution value)
+        {
+            return value switch
+            {
+                PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution.RESOLUTION720 => "RESOLUTION_720",
+                _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
+            };
+        }
+        /// <summary>
+        /// Converts an string to a enum.
+        /// </summary>
+        public static PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution? ToEnum(string value)
+        {
+            return value switch
+            {
+                "RESOLUTION_720" => PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution.RESOLUTION720,
+                _ => null,
+            };
+        }
+    }
+}

--- a/src/libs/Leonardo/Generated/Leonardo.Models.PricingCalculatorServices.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.PricingCalculatorServices.g.cs
@@ -27,6 +27,10 @@ namespace Leonardo
         /// <summary>
         /// 
         /// </summary>
+        VEO3MOTIONVIDEOGENERATION,
+        /// <summary>
+        /// 
+        /// </summary>
         LCMGENERATION,
         /// <summary>
         /// 
@@ -62,6 +66,7 @@ namespace Leonardo
                 PricingCalculatorServices.FANTASYAVATARGENERATION => "FANTASY_AVATAR_GENERATION",
                 PricingCalculatorServices.MOTIONSVDGENERATION => "MOTION_SVD_GENERATION",
                 PricingCalculatorServices.MOTIONVIDEOGENERATION => "MOTION_VIDEO_GENERATION",
+                PricingCalculatorServices.VEO3MOTIONVIDEOGENERATION => "VEO3_MOTION_VIDEO_GENERATION",
                 PricingCalculatorServices.LCMGENERATION => "LCM_GENERATION",
                 PricingCalculatorServices.MODELTRAINING => "MODEL_TRAINING",
                 PricingCalculatorServices.TEXTUREGENERATION => "TEXTURE_GENERATION",
@@ -81,6 +86,7 @@ namespace Leonardo
                 "FANTASY_AVATAR_GENERATION" => PricingCalculatorServices.FANTASYAVATARGENERATION,
                 "MOTION_SVD_GENERATION" => PricingCalculatorServices.MOTIONSVDGENERATION,
                 "MOTION_VIDEO_GENERATION" => PricingCalculatorServices.MOTIONVIDEOGENERATION,
+                "VEO3_MOTION_VIDEO_GENERATION" => PricingCalculatorServices.VEO3MOTIONVIDEOGENERATION,
                 "LCM_GENERATION" => PricingCalculatorServices.LCMGENERATION,
                 "MODEL_TRAINING" => PricingCalculatorServices.MODELTRAINING,
                 "TEXTURE_GENERATION" => PricingCalculatorServices.TEXTUREGENERATION,

--- a/src/libs/Leonardo/openapi.yaml
+++ b/src/libs/Leonardo/openapi.yaml
@@ -3273,8 +3273,20 @@ paths:
                         resolution:
                           title: String
                           type: string
-                          description: The resolution of the video. Must be enum value of FAST and QUALITY.
+                          description: The resolution of the video. Must be RESOLUTION_480 or RESOLUTION_720.
                       description: Parameters for MOTION_VIDEO_GENERATION service
+                      nullable: true
+                    VEO3_MOTION_VIDEO_GENERATION:
+                      title: Object
+                      type: object
+                      properties:
+                        resolution:
+                          title: String
+                          enum:
+                            - RESOLUTION_720
+                          type: string
+                          description: The resolution of the video. Supported resolution for VEO3 is RESOLUTION_720.
+                      description: Parameters for VEO3_MOTION_VIDEO_GENERATION service
                       nullable: true
                     LCM_GENERATION:
                       title: Object
@@ -3802,6 +3814,7 @@ components:
         - FANTASY_AVATAR_GENERATION
         - MOTION_SVD_GENERATION
         - MOTION_VIDEO_GENERATION
+        - VEO3_MOTION_VIDEO_GENERATION
         - LCM_GENERATION
         - MODEL_TRAINING
         - TEXTURE_GENERATION


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the new VEO3 Motion Video Generation service in the pricing calculator, with resolution restricted to 720p.

* **Improvements**
  * Updated descriptions for motion video generation resolution options to clarify available choices (480p or 720p).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->