### PR TITLE
feat:Add optional model property to generations-image-to-video OpenAPI endpoint

### DIFF
--- a/src/libs/Leonardo/Generated/Leonardo..JsonSerializerContext.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo..JsonSerializerContext.g.cs
@@ -55,6 +55,8 @@ namespace Leonardo
             typeof(global::Leonardo.JsonConverters.CreateImageToVideoGenerationRequestImageTypeNullableJsonConverter),
             typeof(global::Leonardo.JsonConverters.CreateImageToVideoGenerationRequestResolutionJsonConverter),
             typeof(global::Leonardo.JsonConverters.CreateImageToVideoGenerationRequestResolutionNullableJsonConverter),
+            typeof(global::Leonardo.JsonConverters.CreateImageToVideoGenerationRequestModelJsonConverter),
+            typeof(global::Leonardo.JsonConverters.CreateImageToVideoGenerationRequestModelNullableJsonConverter),
             typeof(global::Leonardo.JsonConverters.CreateTextToVideoGenerationRequestResolutionJsonConverter),
             typeof(global::Leonardo.JsonConverters.CreateTextToVideoGenerationRequestResolutionNullableJsonConverter),
             typeof(global::Leonardo.JsonConverters.CreateTextToVideoGenerationRequestModelJsonConverter),

--- a/src/libs/Leonardo/Generated/Leonardo.IMotionClient.CreateImageToVideoGeneration.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.IMotionClient.CreateImageToVideoGeneration.g.cs
@@ -32,6 +32,10 @@ namespace Leonardo
         /// The resolution of the video. Defaults to RESOLUTION_480 if not specified.<br/>
         /// Default Value: RESOLUTION_480
         /// </param>
+        /// <param name="model">
+        /// The model to use for the video generation. Defaults to MOTION2 if not specified.<br/>
+        /// Default Value: MOTION2
+        /// </param>
         /// <param name="frameInterpolation">
         /// Smoothly blend frames for fluid video transitions using Interpolation.
         /// </param>
@@ -54,6 +58,7 @@ namespace Leonardo
             string imageId,
             global::Leonardo.CreateImageToVideoGenerationRequestImageType imageType,
             global::Leonardo.CreateImageToVideoGenerationRequestResolution? resolution = default,
+            global::Leonardo.CreateImageToVideoGenerationRequestModel? model = default,
             bool? frameInterpolation = default,
             bool? isPublic = default,
             string? negativePrompt = default,

--- a/src/libs/Leonardo/Generated/Leonardo.JsonConverters.CreateImageToVideoGenerationRequestModel.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.JsonConverters.CreateImageToVideoGenerationRequestModel.g.cs
@@ -1,0 +1,53 @@
+#nullable enable
+
+namespace Leonardo.JsonConverters
+{
+    /// <inheritdoc />
+    public sealed class CreateImageToVideoGenerationRequestModelJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Leonardo.CreateImageToVideoGenerationRequestModel>
+    {
+        /// <inheritdoc />
+        public override global::Leonardo.CreateImageToVideoGenerationRequestModel Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case global::System.Text.Json.JsonTokenType.String:
+                {
+                    var stringValue = reader.GetString();
+                    if (stringValue != null)
+                    {
+                        return global::Leonardo.CreateImageToVideoGenerationRequestModelExtensions.ToEnum(stringValue) ?? default;
+                    }
+                    
+                    break;
+                }
+                case global::System.Text.Json.JsonTokenType.Number:
+                {
+                    var numValue = reader.GetInt32();
+                    return (global::Leonardo.CreateImageToVideoGenerationRequestModel)numValue;
+                }
+                case global::System.Text.Json.JsonTokenType.Null:
+                {
+                    return default(global::Leonardo.CreateImageToVideoGenerationRequestModel);
+                }
+                default:
+                    throw new global::System.ArgumentOutOfRangeException(nameof(reader));
+            }
+
+            return default;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::Leonardo.CreateImageToVideoGenerationRequestModel value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            writer = writer ?? throw new global::System.ArgumentNullException(nameof(writer));
+
+            writer.WriteStringValue(global::Leonardo.CreateImageToVideoGenerationRequestModelExtensions.ToValueString(value));
+        }
+    }
+}

--- a/src/libs/Leonardo/Generated/Leonardo.JsonConverters.CreateImageToVideoGenerationRequestModelNullable.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.JsonConverters.CreateImageToVideoGenerationRequestModelNullable.g.cs
@@ -1,0 +1,60 @@
+#nullable enable
+
+namespace Leonardo.JsonConverters
+{
+    /// <inheritdoc />
+    public sealed class CreateImageToVideoGenerationRequestModelNullableJsonConverter : global::System.Text.Json.Serialization.JsonConverter<global::Leonardo.CreateImageToVideoGenerationRequestModel?>
+    {
+        /// <inheritdoc />
+        public override global::Leonardo.CreateImageToVideoGenerationRequestModel? Read(
+            ref global::System.Text.Json.Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case global::System.Text.Json.JsonTokenType.String:
+                {
+                    var stringValue = reader.GetString();
+                    if (stringValue != null)
+                    {
+                        return global::Leonardo.CreateImageToVideoGenerationRequestModelExtensions.ToEnum(stringValue);
+                    }
+                    
+                    break;
+                }
+                case global::System.Text.Json.JsonTokenType.Number:
+                {
+                    var numValue = reader.GetInt32();
+                    return (global::Leonardo.CreateImageToVideoGenerationRequestModel)numValue;
+                }
+                case global::System.Text.Json.JsonTokenType.Null:
+                {
+                    return default(global::Leonardo.CreateImageToVideoGenerationRequestModel?);
+                }
+                default:
+                    throw new global::System.ArgumentOutOfRangeException(nameof(reader));
+            }
+
+            return default;
+        }
+
+        /// <inheritdoc />
+        public override void Write(
+            global::System.Text.Json.Utf8JsonWriter writer,
+            global::Leonardo.CreateImageToVideoGenerationRequestModel? value,
+            global::System.Text.Json.JsonSerializerOptions options)
+        {
+            writer = writer ?? throw new global::System.ArgumentNullException(nameof(writer));
+
+            if (value == null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteStringValue(global::Leonardo.CreateImageToVideoGenerationRequestModelExtensions.ToValueString(value.Value));
+            }
+        }
+    }
+}

--- a/src/libs/Leonardo/Generated/Leonardo.JsonSerializerContextTypes.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.JsonSerializerContextTypes.g.cs
@@ -174,698 +174,702 @@ namespace Leonardo
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateTextToVideoGenerationRequest? Type37 { get; set; }
+        public global::Leonardo.CreateImageToVideoGenerationRequestModel? Type37 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateTextToVideoGenerationRequestResolution? Type38 { get; set; }
+        public global::Leonardo.CreateTextToVideoGenerationRequest? Type38 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateTextToVideoGenerationRequestModel? Type39 { get; set; }
+        public global::Leonardo.CreateTextToVideoGenerationRequestResolution? Type39 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVideoUpscaleRequest? Type40 { get; set; }
+        public global::Leonardo.CreateTextToVideoGenerationRequestModel? Type40 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVideoUpscaleRequestResolution? Type41 { get; set; }
+        public global::Leonardo.CreateVideoUpscaleRequest? Type41 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateLCMGenerationRequest? Type42 { get; set; }
+        public global::Leonardo.CreateVideoUpscaleRequestResolution? Type42 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PerformInstantRefineRequest? Type43 { get; set; }
+        public global::Leonardo.CreateLCMGenerationRequest? Type43 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PerformInpaintingLCMRequest? Type44 { get; set; }
+        public global::Leonardo.PerformInstantRefineRequest? Type44 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PerformAlchemyUpscaleLCMRequest? Type45 { get; set; }
+        public global::Leonardo.PerformInpaintingLCMRequest? Type45 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetTextureGenerationsByModelIdRequest? Type46 { get; set; }
+        public global::Leonardo.PerformAlchemyUpscaleLCMRequest? Type46 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetTextureGenerationByIdRequest? Type47 { get; set; }
+        public global::Leonardo.GetTextureGenerationsByModelIdRequest? Type47 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteTextureGenerationByIdRequest? Type48 { get; set; }
+        public global::Leonardo.GetTextureGenerationByIdRequest? Type48 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadModelAssetRequest? Type49 { get; set; }
+        public global::Leonardo.DeleteTextureGenerationByIdRequest? Type49 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.Get3DModelsByUserIdRequest? Type50 { get; set; }
+        public global::Leonardo.UploadModelAssetRequest? Type50 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.Get3DModelByIdRequest? Type51 { get; set; }
+        public global::Leonardo.Get3DModelsByUserIdRequest? Type51 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.Delete3DModelByIdRequest? Type52 { get; set; }
+        public global::Leonardo.Get3DModelByIdRequest? Type52 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadInitImageRequest? Type53 { get; set; }
+        public global::Leonardo.Delete3DModelByIdRequest? Type53 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadCanvasInitImageRequest? Type54 { get; set; }
+        public global::Leonardo.UploadInitImageRequest? Type54 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVariationUnzoomRequest? Type55 { get; set; }
+        public global::Leonardo.UploadCanvasInitImageRequest? Type55 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVariationUpscaleRequest? Type56 { get; set; }
+        public global::Leonardo.CreateVariationUnzoomRequest? Type56 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVariationNoBGRequest? Type57 { get; set; }
+        public global::Leonardo.CreateVariationUpscaleRequest? Type57 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateUniversalUpscalerJobRequest? Type58 { get; set; }
+        public global::Leonardo.CreateVariationNoBGRequest? Type58 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateDatasetRequest? Type59 { get; set; }
+        public global::Leonardo.CreateUniversalUpscalerJobRequest? Type59 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadDatasetImageRequest? Type60 { get; set; }
+        public global::Leonardo.CreateDatasetRequest? Type60 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadDatasetImageFromGenRequest? Type61 { get; set; }
+        public global::Leonardo.UploadDatasetImageRequest? Type61 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateModelRequest? Type62 { get; set; }
+        public global::Leonardo.UploadDatasetImageFromGenRequest? Type62 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateModelRequestSdVersion? Type63 { get; set; }
+        public global::Leonardo.CreateModelRequest? Type63 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateElementRequest? Type64 { get; set; }
+        public global::Leonardo.CreateModelRequestSdVersion? Type64 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateElementRequestSdVersion? Type65 { get; set; }
+        public global::Leonardo.CreateElementRequest? Type65 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PromptImproveRequest? Type66 { get; set; }
+        public global::Leonardo.CreateElementRequestSdVersion? Type66 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequest? Type67 { get; set; }
+        public global::Leonardo.PromptImproveRequest? Type67 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequestServiceParams? Type68 { get; set; }
+        public global::Leonardo.PricingCalculatorRequest? Type68 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequestServiceParamsIMAGEGENERATION? Type69 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParams? Type69 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequestServiceParamsFANTASYAVATARGENERATION? Type70 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsIMAGEGENERATION? Type70 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public object? Type71 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsFANTASYAVATARGENERATION? Type71 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequestServiceParamsMOTIONVIDEOGENERATION? Type72 { get; set; }
+        public object? Type72 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION? Type73 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsMOTIONVIDEOGENERATION? Type73 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution? Type74 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATION? Type74 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequestServiceParamsLCMGENERATION? Type75 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsVEO3MOTIONVIDEOGENERATIONResolution? Type75 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequestServiceParamsMODELTRAINING? Type76 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsLCMGENERATION? Type76 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequestServiceParamsMODELTRAININGSdVersion? Type77 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsMODELTRAINING? Type77 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequestServiceParamsTEXTUREGENERATION? Type78 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsMODELTRAININGSdVersion? Type78 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequestServiceParamsUNIVERSALUPSCALER? Type79 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsTEXTUREGENERATION? Type79 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorRequestServiceParamsUNIVERSALUPSCALERULTRA? Type80 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsUNIVERSALUPSCALER? Type80 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetUserSelfResponse? Type81 { get; set; }
+        public global::Leonardo.PricingCalculatorRequestServiceParamsUNIVERSALUPSCALERULTRA? Type81 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetUserSelfResponseUserDetail>? Type82 { get; set; }
+        public global::Leonardo.GetUserSelfResponse? Type82 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetUserSelfResponseUserDetail? Type83 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetUserSelfResponseUserDetail>? Type83 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetUserSelfResponseUserDetailUser? Type84 { get; set; }
+        public global::Leonardo.GetUserSelfResponseUserDetail? Type84 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateGenerationResponse? Type85 { get; set; }
+        public global::Leonardo.GetUserSelfResponseUserDetailUser? Type85 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateGenerationResponseSdGenerationJob? Type86 { get; set; }
+        public global::Leonardo.CreateGenerationResponse? Type86 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationByIdResponse? Type87 { get; set; }
+        public global::Leonardo.CreateGenerationResponseSdGenerationJob? Type87 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationByIdResponseGenerationsByPk? Type88 { get; set; }
+        public global::Leonardo.GetGenerationByIdResponse? Type88 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationByIdResponseGenerationsByPkGeneratedImage>? Type89 { get; set; }
+        public global::Leonardo.GetGenerationByIdResponseGenerationsByPk? Type89 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationByIdResponseGenerationsByPkGeneratedImage? Type90 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationByIdResponseGenerationsByPkGeneratedImage>? Type90 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationByIdResponseGenerationsByPkGeneratedImageGeneratedImageVariationGeneric>? Type91 { get; set; }
+        public global::Leonardo.GetGenerationByIdResponseGenerationsByPkGeneratedImage? Type91 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationByIdResponseGenerationsByPkGeneratedImageGeneratedImageVariationGeneric? Type92 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationByIdResponseGenerationsByPkGeneratedImageGeneratedImageVariationGeneric>? Type92 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationByIdResponseGenerationsByPkGenerationElement>? Type93 { get; set; }
+        public global::Leonardo.GetGenerationByIdResponseGenerationsByPkGeneratedImageGeneratedImageVariationGeneric? Type93 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationByIdResponseGenerationsByPkGenerationElement? Type94 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationByIdResponseGenerationsByPkGenerationElement>? Type94 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationByIdResponseGenerationsByPkGenerationElementLora? Type95 { get; set; }
+        public global::Leonardo.GetGenerationByIdResponseGenerationsByPkGenerationElement? Type95 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteGenerationByIdResponse? Type96 { get; set; }
+        public global::Leonardo.GetGenerationByIdResponseGenerationsByPkGenerationElementLora? Type96 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteGenerationByIdResponseDeleteGenerationsByPk? Type97 { get; set; }
+        public global::Leonardo.DeleteGenerationByIdResponse? Type97 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationsByUserIdResponse? Type98 { get; set; }
+        public global::Leonardo.DeleteGenerationByIdResponseDeleteGenerationsByPk? Type98 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationsByUserIdResponseGeneration>? Type99 { get; set; }
+        public global::Leonardo.GetGenerationsByUserIdResponse? Type99 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationsByUserIdResponseGeneration? Type100 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationsByUserIdResponseGeneration>? Type100 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationsByUserIdResponseGenerationGeneratedImage>? Type101 { get; set; }
+        public global::Leonardo.GetGenerationsByUserIdResponseGeneration? Type101 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationsByUserIdResponseGenerationGeneratedImage? Type102 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationsByUserIdResponseGenerationGeneratedImage>? Type102 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationsByUserIdResponseGenerationGeneratedImageGeneratedImageVariationGeneric>? Type103 { get; set; }
+        public global::Leonardo.GetGenerationsByUserIdResponseGenerationGeneratedImage? Type103 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationsByUserIdResponseGenerationGeneratedImageGeneratedImageVariationGeneric? Type104 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationsByUserIdResponseGenerationGeneratedImageGeneratedImageVariationGeneric>? Type104 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationsByUserIdResponseGenerationGenerationElement>? Type105 { get; set; }
+        public global::Leonardo.GetGenerationsByUserIdResponseGenerationGeneratedImageGeneratedImageVariationGeneric? Type105 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationsByUserIdResponseGenerationGenerationElement? Type106 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetGenerationsByUserIdResponseGenerationGenerationElement>? Type106 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetGenerationsByUserIdResponseGenerationGenerationElementLora? Type107 { get; set; }
+        public global::Leonardo.GetGenerationsByUserIdResponseGenerationGenerationElement? Type107 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateTextureGenerationResponse? Type108 { get; set; }
+        public global::Leonardo.GetGenerationsByUserIdResponseGenerationGenerationElementLora? Type108 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateTextureGenerationResponseTextureGenerationJob? Type109 { get; set; }
+        public global::Leonardo.CreateTextureGenerationResponse? Type109 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateSVDMotionGenerationResponse? Type110 { get; set; }
+        public global::Leonardo.CreateTextureGenerationResponseTextureGenerationJob? Type110 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateSVDMotionGenerationResponseMotionSvdGenerationJob? Type111 { get; set; }
+        public global::Leonardo.CreateSVDMotionGenerationResponse? Type111 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateImageToVideoGenerationResponse? Type112 { get; set; }
+        public global::Leonardo.CreateSVDMotionGenerationResponseMotionSvdGenerationJob? Type112 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateImageToVideoGenerationResponseMotionVideoGenerationJob? Type113 { get; set; }
+        public global::Leonardo.CreateImageToVideoGenerationResponse? Type113 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateTextToVideoGenerationResponse? Type114 { get; set; }
+        public global::Leonardo.CreateImageToVideoGenerationResponseMotionVideoGenerationJob? Type114 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateTextToVideoGenerationResponseMotionVideoGenerationJob? Type115 { get; set; }
+        public global::Leonardo.CreateTextToVideoGenerationResponse? Type115 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVideoUpscaleResponse? Type116 { get; set; }
+        public global::Leonardo.CreateTextToVideoGenerationResponseMotionVideoGenerationJob? Type116 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVideoUpscaleResponseMotionVideoGenerationJob? Type117 { get; set; }
+        public global::Leonardo.CreateVideoUpscaleResponse? Type117 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateLCMGenerationResponse? Type118 { get; set; }
+        public global::Leonardo.CreateVideoUpscaleResponseMotionVideoGenerationJob? Type118 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateLCMGenerationResponseLcmGenerationJob? Type119 { get; set; }
+        public global::Leonardo.CreateLCMGenerationResponse? Type119 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PerformInstantRefineResponse? Type120 { get; set; }
+        public global::Leonardo.CreateLCMGenerationResponseLcmGenerationJob? Type120 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PerformInstantRefineResponseLcmGenerationJob? Type121 { get; set; }
+        public global::Leonardo.PerformInstantRefineResponse? Type121 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PerformInpaintingLCMResponse? Type122 { get; set; }
+        public global::Leonardo.PerformInstantRefineResponseLcmGenerationJob? Type122 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PerformInpaintingLCMResponseLcmGenerationJob? Type123 { get; set; }
+        public global::Leonardo.PerformInpaintingLCMResponse? Type123 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PerformAlchemyUpscaleLCMResponse? Type124 { get; set; }
+        public global::Leonardo.PerformInpaintingLCMResponseLcmGenerationJob? Type124 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PerformAlchemyUpscaleLCMResponseLcmGenerationJob? Type125 { get; set; }
+        public global::Leonardo.PerformAlchemyUpscaleLCMResponse? Type125 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetTextureGenerationsByModelIdResponse? Type126 { get; set; }
+        public global::Leonardo.PerformAlchemyUpscaleLCMResponseLcmGenerationJob? Type126 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetTextureGenerationsByModelIdResponseModelAssetTextureGeneration>? Type127 { get; set; }
+        public global::Leonardo.GetTextureGenerationsByModelIdResponse? Type127 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetTextureGenerationsByModelIdResponseModelAssetTextureGeneration? Type128 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetTextureGenerationsByModelIdResponseModelAssetTextureGeneration>? Type128 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetTextureGenerationsByModelIdResponseModelAssetTextureGenerationModelAssetTextureImage>? Type129 { get; set; }
+        public global::Leonardo.GetTextureGenerationsByModelIdResponseModelAssetTextureGeneration? Type129 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetTextureGenerationsByModelIdResponseModelAssetTextureGenerationModelAssetTextureImage? Type130 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetTextureGenerationsByModelIdResponseModelAssetTextureGenerationModelAssetTextureImage>? Type130 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetTextureGenerationByIdResponse? Type131 { get; set; }
+        public global::Leonardo.GetTextureGenerationsByModelIdResponseModelAssetTextureGenerationModelAssetTextureImage? Type131 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetTextureGenerationByIdResponseModelAssetTextureGenerationsByPk? Type132 { get; set; }
+        public global::Leonardo.GetTextureGenerationByIdResponse? Type132 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetTextureGenerationByIdResponseModelAssetTextureGenerationsByPkModelAssetTextureImage>? Type133 { get; set; }
+        public global::Leonardo.GetTextureGenerationByIdResponseModelAssetTextureGenerationsByPk? Type133 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetTextureGenerationByIdResponseModelAssetTextureGenerationsByPkModelAssetTextureImage? Type134 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetTextureGenerationByIdResponseModelAssetTextureGenerationsByPkModelAssetTextureImage>? Type134 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteTextureGenerationByIdResponse? Type135 { get; set; }
+        public global::Leonardo.GetTextureGenerationByIdResponseModelAssetTextureGenerationsByPkModelAssetTextureImage? Type135 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteTextureGenerationByIdResponseDeleteModelAssetTextureGenerationsByPk? Type136 { get; set; }
+        public global::Leonardo.DeleteTextureGenerationByIdResponse? Type136 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadModelAssetResponse? Type137 { get; set; }
+        public global::Leonardo.DeleteTextureGenerationByIdResponseDeleteModelAssetTextureGenerationsByPk? Type137 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadModelAssetResponseUploadModelAsset? Type138 { get; set; }
+        public global::Leonardo.UploadModelAssetResponse? Type138 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.Get3DModelsByUserIdResponse? Type139 { get; set; }
+        public global::Leonardo.UploadModelAssetResponseUploadModelAsset? Type139 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.Get3DModelsByUserIdResponseModelAsset>? Type140 { get; set; }
+        public global::Leonardo.Get3DModelsByUserIdResponse? Type140 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.Get3DModelsByUserIdResponseModelAsset? Type141 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.Get3DModelsByUserIdResponseModelAsset>? Type141 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.Get3DModelByIdResponse? Type142 { get; set; }
+        public global::Leonardo.Get3DModelsByUserIdResponseModelAsset? Type142 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.Get3DModelByIdResponseModelAssetsByPk? Type143 { get; set; }
+        public global::Leonardo.Get3DModelByIdResponse? Type143 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.Delete3DModelByIdResponse? Type144 { get; set; }
+        public global::Leonardo.Get3DModelByIdResponseModelAssetsByPk? Type144 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.Delete3DModelByIdResponseDeleteModelAssetsByPk? Type145 { get; set; }
+        public global::Leonardo.Delete3DModelByIdResponse? Type145 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadInitImageResponse? Type146 { get; set; }
+        public global::Leonardo.Delete3DModelByIdResponseDeleteModelAssetsByPk? Type146 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadInitImageResponseUploadInitImage? Type147 { get; set; }
+        public global::Leonardo.UploadInitImageResponse? Type147 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetInitImageByIdResponse? Type148 { get; set; }
+        public global::Leonardo.UploadInitImageResponseUploadInitImage? Type148 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetInitImageByIdResponseInitImagesByPk? Type149 { get; set; }
+        public global::Leonardo.GetInitImageByIdResponse? Type149 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteInitImageByIdResponse? Type150 { get; set; }
+        public global::Leonardo.GetInitImageByIdResponseInitImagesByPk? Type150 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteInitImageByIdResponseDeleteInitImagesByPk? Type151 { get; set; }
+        public global::Leonardo.DeleteInitImageByIdResponse? Type151 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadCanvasInitImageResponse? Type152 { get; set; }
+        public global::Leonardo.DeleteInitImageByIdResponseDeleteInitImagesByPk? Type152 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadCanvasInitImageResponseUploadCanvasInitImage? Type153 { get; set; }
+        public global::Leonardo.UploadCanvasInitImageResponse? Type153 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVariationUnzoomResponse? Type154 { get; set; }
+        public global::Leonardo.UploadCanvasInitImageResponseUploadCanvasInitImage? Type154 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVariationUnzoomResponseSdUnzoomJob? Type155 { get; set; }
+        public global::Leonardo.CreateVariationUnzoomResponse? Type155 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVariationUpscaleResponse? Type156 { get; set; }
+        public global::Leonardo.CreateVariationUnzoomResponseSdUnzoomJob? Type156 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVariationUpscaleResponseSdUpscaleJob? Type157 { get; set; }
+        public global::Leonardo.CreateVariationUpscaleResponse? Type157 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVariationNoBGResponse? Type158 { get; set; }
+        public global::Leonardo.CreateVariationUpscaleResponseSdUpscaleJob? Type158 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateVariationNoBGResponseSdNobgJob? Type159 { get; set; }
+        public global::Leonardo.CreateVariationNoBGResponse? Type159 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateUniversalUpscalerJobResponse? Type160 { get; set; }
+        public global::Leonardo.CreateVariationNoBGResponseSdNobgJob? Type160 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateUniversalUpscalerJobResponseUniversalUpscaler? Type161 { get; set; }
+        public global::Leonardo.CreateUniversalUpscalerJobResponse? Type161 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetVariationByIdResponse? Type162 { get; set; }
+        public global::Leonardo.CreateUniversalUpscalerJobResponseUniversalUpscaler? Type162 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetVariationByIdResponseGeneratedImageVariationGenericItem>? Type163 { get; set; }
+        public global::Leonardo.GetVariationByIdResponse? Type163 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetVariationByIdResponseGeneratedImageVariationGenericItem? Type164 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetVariationByIdResponseGeneratedImageVariationGenericItem>? Type164 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetMotionVariationByIdResponse? Type165 { get; set; }
+        public global::Leonardo.GetVariationByIdResponseGeneratedImageVariationGenericItem? Type165 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetMotionVariationByIdResponseGeneratedImageVariationMotionItem>? Type166 { get; set; }
+        public global::Leonardo.GetMotionVariationByIdResponse? Type166 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetMotionVariationByIdResponseGeneratedImageVariationMotionItem? Type167 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetMotionVariationByIdResponseGeneratedImageVariationMotionItem>? Type167 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateDatasetResponse? Type168 { get; set; }
+        public global::Leonardo.GetMotionVariationByIdResponseGeneratedImageVariationMotionItem? Type168 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateDatasetResponseInsertDatasetsOne? Type169 { get; set; }
+        public global::Leonardo.CreateDatasetResponse? Type169 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetDatasetByIdResponse? Type170 { get; set; }
+        public global::Leonardo.CreateDatasetResponseInsertDatasetsOne? Type170 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetDatasetByIdResponseDatasetsByPk? Type171 { get; set; }
+        public global::Leonardo.GetDatasetByIdResponse? Type171 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetDatasetByIdResponseDatasetsByPkDatasetImage>? Type172 { get; set; }
+        public global::Leonardo.GetDatasetByIdResponseDatasetsByPk? Type172 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetDatasetByIdResponseDatasetsByPkDatasetImage? Type173 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetDatasetByIdResponseDatasetsByPkDatasetImage>? Type173 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteDatasetByIdResponse? Type174 { get; set; }
+        public global::Leonardo.GetDatasetByIdResponseDatasetsByPkDatasetImage? Type174 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteDatasetByIdResponseDeleteDatasetsByPk? Type175 { get; set; }
+        public global::Leonardo.DeleteDatasetByIdResponse? Type175 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadDatasetImageResponse? Type176 { get; set; }
+        public global::Leonardo.DeleteDatasetByIdResponseDeleteDatasetsByPk? Type176 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadDatasetImageResponseUploadDatasetImage? Type177 { get; set; }
+        public global::Leonardo.UploadDatasetImageResponse? Type177 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadDatasetImageFromGenResponse? Type178 { get; set; }
+        public global::Leonardo.UploadDatasetImageResponseUploadDatasetImage? Type178 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.UploadDatasetImageFromGenResponseUploadDatasetImageFromGen? Type179 { get; set; }
+        public global::Leonardo.UploadDatasetImageFromGenResponse? Type179 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateModelResponse? Type180 { get; set; }
+        public global::Leonardo.UploadDatasetImageFromGenResponseUploadDatasetImageFromGen? Type180 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateModelResponseSdTrainingJob? Type181 { get; set; }
+        public global::Leonardo.CreateModelResponse? Type181 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetModelByIdResponse? Type182 { get; set; }
+        public global::Leonardo.CreateModelResponseSdTrainingJob? Type182 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetModelByIdResponseCustomModelsByPk? Type183 { get; set; }
+        public global::Leonardo.GetModelByIdResponse? Type183 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteModelByIdResponse? Type184 { get; set; }
+        public global::Leonardo.GetModelByIdResponseCustomModelsByPk? Type184 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteModelByIdResponseDeleteCustomModelsByPk? Type185 { get; set; }
+        public global::Leonardo.DeleteModelByIdResponse? Type185 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetCustomModelsByUserIdResponse? Type186 { get; set; }
+        public global::Leonardo.DeleteModelByIdResponseDeleteCustomModelsByPk? Type186 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetCustomModelsByUserIdResponseCustomModel>? Type187 { get; set; }
+        public global::Leonardo.GetCustomModelsByUserIdResponse? Type187 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetCustomModelsByUserIdResponseCustomModel? Type188 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetCustomModelsByUserIdResponseCustomModel>? Type188 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.ListPlatformModelsResponse? Type189 { get; set; }
+        public global::Leonardo.GetCustomModelsByUserIdResponseCustomModel? Type189 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.ListPlatformModelsResponseCustomModel>? Type190 { get; set; }
+        public global::Leonardo.ListPlatformModelsResponse? Type190 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.ListPlatformModelsResponseCustomModel? Type191 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.ListPlatformModelsResponseCustomModel>? Type191 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.ListPlatformModelsResponseCustomModelGeneratedImage? Type192 { get; set; }
+        public global::Leonardo.ListPlatformModelsResponseCustomModel? Type192 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetElementByIdResponse? Type193 { get; set; }
+        public global::Leonardo.ListPlatformModelsResponseCustomModelGeneratedImage? Type193 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetElementByIdResponseUserLorasByPk? Type194 { get; set; }
+        public global::Leonardo.GetElementByIdResponse? Type194 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteElementByIdResponse? Type195 { get; set; }
+        public global::Leonardo.GetElementByIdResponseUserLorasByPk? Type195 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.DeleteElementByIdResponseDeleteUserLorasByPk? Type196 { get; set; }
+        public global::Leonardo.DeleteElementByIdResponse? Type196 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetCustomElementsByUserIdResponse? Type197 { get; set; }
+        public global::Leonardo.DeleteElementByIdResponseDeleteUserLorasByPk? Type197 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.GetCustomElementsByUserIdResponseUserLora>? Type198 { get; set; }
+        public global::Leonardo.GetCustomElementsByUserIdResponse? Type198 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.GetCustomElementsByUserIdResponseUserLora? Type199 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.GetCustomElementsByUserIdResponseUserLora>? Type199 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateElementResponse? Type200 { get; set; }
+        public global::Leonardo.GetCustomElementsByUserIdResponseUserLora? Type200 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.CreateElementResponseSdTrainingJob? Type201 { get; set; }
+        public global::Leonardo.CreateElementResponse? Type201 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.ListElementsResponse? Type202 { get; set; }
+        public global::Leonardo.CreateElementResponseSdTrainingJob? Type202 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::System.Collections.Generic.IList<global::Leonardo.ListElementsResponseLora>? Type203 { get; set; }
+        public global::Leonardo.ListElementsResponse? Type203 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.ListElementsResponseLora? Type204 { get; set; }
+        public global::System.Collections.Generic.IList<global::Leonardo.ListElementsResponseLora>? Type204 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PromptRandomResponse? Type205 { get; set; }
+        public global::Leonardo.ListElementsResponseLora? Type205 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PromptRandomResponsePromptGeneration? Type206 { get; set; }
+        public global::Leonardo.PromptRandomResponse? Type206 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PromptImproveResponse? Type207 { get; set; }
+        public global::Leonardo.PromptRandomResponsePromptGeneration? Type207 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PromptImproveResponsePromptGeneration? Type208 { get; set; }
+        public global::Leonardo.PromptImproveResponse? Type208 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorResponse? Type209 { get; set; }
+        public global::Leonardo.PromptImproveResponsePromptGeneration? Type209 { get; set; }
         /// <summary>
         /// 
         /// </summary>
-        public global::Leonardo.PricingCalculatorResponseCalculateProductionApiServiceCost? Type210 { get; set; }
+        public global::Leonardo.PricingCalculatorResponse? Type210 { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public global::Leonardo.PricingCalculatorResponseCalculateProductionApiServiceCost? Type211 { get; set; }
     }
 }

--- a/src/libs/Leonardo/Generated/Leonardo.Models.CreateImageToVideoGenerationRequest.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.CreateImageToVideoGenerationRequest.g.cs
@@ -39,6 +39,14 @@ namespace Leonardo
         public global::Leonardo.CreateImageToVideoGenerationRequestResolution? Resolution { get; set; }
 
         /// <summary>
+        /// The model to use for the video generation. Defaults to MOTION2 if not specified.<br/>
+        /// Default Value: MOTION2
+        /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("model")]
+        [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Leonardo.JsonConverters.CreateImageToVideoGenerationRequestModelJsonConverter))]
+        public global::Leonardo.CreateImageToVideoGenerationRequestModel? Model { get; set; }
+
+        /// <summary>
         /// Smoothly blend frames for fluid video transitions using Interpolation.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("frameInterpolation")]
@@ -90,6 +98,10 @@ namespace Leonardo
         /// The resolution of the video. Defaults to RESOLUTION_480 if not specified.<br/>
         /// Default Value: RESOLUTION_480
         /// </param>
+        /// <param name="model">
+        /// The model to use for the video generation. Defaults to MOTION2 if not specified.<br/>
+        /// Default Value: MOTION2
+        /// </param>
         /// <param name="frameInterpolation">
         /// Smoothly blend frames for fluid video transitions using Interpolation.
         /// </param>
@@ -113,6 +125,7 @@ namespace Leonardo
             string imageId,
             global::Leonardo.CreateImageToVideoGenerationRequestImageType imageType,
             global::Leonardo.CreateImageToVideoGenerationRequestResolution? resolution,
+            global::Leonardo.CreateImageToVideoGenerationRequestModel? model,
             bool? frameInterpolation,
             bool? isPublic,
             string? negativePrompt,
@@ -123,6 +136,7 @@ namespace Leonardo
             this.ImageId = imageId ?? throw new global::System.ArgumentNullException(nameof(imageId));
             this.ImageType = imageType;
             this.Resolution = resolution;
+            this.Model = model;
             this.FrameInterpolation = frameInterpolation;
             this.IsPublic = isPublic;
             this.NegativePrompt = negativePrompt;

--- a/src/libs/Leonardo/Generated/Leonardo.Models.CreateImageToVideoGenerationRequestModel.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.CreateImageToVideoGenerationRequestModel.g.cs
@@ -1,0 +1,52 @@
+
+#nullable enable
+
+namespace Leonardo
+{
+    /// <summary>
+    /// The model to use for the video generation. Defaults to MOTION2 if not specified.<br/>
+    /// Default Value: MOTION2
+    /// </summary>
+    public enum CreateImageToVideoGenerationRequestModel
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        MOTION2,
+        /// <summary>
+        /// 
+        /// </summary>
+        VEO3,
+    }
+
+    /// <summary>
+    /// Enum extensions to do fast conversions without the reflection.
+    /// </summary>
+    public static class CreateImageToVideoGenerationRequestModelExtensions
+    {
+        /// <summary>
+        /// Converts an enum to a string.
+        /// </summary>
+        public static string ToValueString(this CreateImageToVideoGenerationRequestModel value)
+        {
+            return value switch
+            {
+                CreateImageToVideoGenerationRequestModel.MOTION2 => "MOTION2",
+                CreateImageToVideoGenerationRequestModel.VEO3 => "VEO3",
+                _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
+            };
+        }
+        /// <summary>
+        /// Converts an string to a enum.
+        /// </summary>
+        public static CreateImageToVideoGenerationRequestModel? ToEnum(string value)
+        {
+            return value switch
+            {
+                "MOTION2" => CreateImageToVideoGenerationRequestModel.MOTION2,
+                "VEO3" => CreateImageToVideoGenerationRequestModel.VEO3,
+                _ => null,
+            };
+        }
+    }
+}

--- a/src/libs/Leonardo/Generated/Leonardo.MotionClient.CreateImageToVideoGeneration.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.MotionClient.CreateImageToVideoGeneration.g.cs
@@ -183,6 +183,10 @@ namespace Leonardo
         /// The resolution of the video. Defaults to RESOLUTION_480 if not specified.<br/>
         /// Default Value: RESOLUTION_480
         /// </param>
+        /// <param name="model">
+        /// The model to use for the video generation. Defaults to MOTION2 if not specified.<br/>
+        /// Default Value: MOTION2
+        /// </param>
         /// <param name="frameInterpolation">
         /// Smoothly blend frames for fluid video transitions using Interpolation.
         /// </param>
@@ -205,6 +209,7 @@ namespace Leonardo
             string imageId,
             global::Leonardo.CreateImageToVideoGenerationRequestImageType imageType,
             global::Leonardo.CreateImageToVideoGenerationRequestResolution? resolution = default,
+            global::Leonardo.CreateImageToVideoGenerationRequestModel? model = default,
             bool? frameInterpolation = default,
             bool? isPublic = default,
             string? negativePrompt = default,
@@ -218,6 +223,7 @@ namespace Leonardo
                 ImageId = imageId,
                 ImageType = imageType,
                 Resolution = resolution,
+                Model = model,
                 FrameInterpolation = frameInterpolation,
                 IsPublic = isPublic,
                 NegativePrompt = negativePrompt,

--- a/src/libs/Leonardo/openapi.yaml
+++ b/src/libs/Leonardo/openapi.yaml
@@ -852,6 +852,14 @@ paths:
                   description: The resolution of the video. Defaults to RESOLUTION_480 if not specified.
                   default: RESOLUTION_480
                   nullable: true
+                model:
+                  title: String
+                  enum:
+                    - MOTION2
+                    - VEO3
+                  description: The model to use for the video generation. Defaults to MOTION2 if not specified.
+                  default: MOTION2
+                  nullable: true
                 frameInterpolation:
                   title: Boolean
                   type: boolean


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional "model" parameter to the image-to-video generation endpoint, allowing users to select between "MOTION2" and "VEO3" models for video generation. If not specified, "MOTION2" will be used by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->