### PR TITLE
feat:Expand resolution enum to include RESOLUTION_1080 in image and text to video endpoints

### DIFF
--- a/src/libs/Leonardo/Generated/Leonardo.IMotionClient.CreateImageToVideoGeneration.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.IMotionClient.CreateImageToVideoGeneration.g.cs
@@ -29,7 +29,7 @@ namespace Leonardo
         /// Type indicating whether the init image is uploaded or generated. Use only image or imageId with imageType.
         /// </param>
         /// <param name="resolution">
-        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified.<br/>
+        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
         /// Default Value: RESOLUTION_480
         /// </param>
         /// <param name="model">

--- a/src/libs/Leonardo/Generated/Leonardo.IMotionClient.CreateTextToVideoGeneration.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.IMotionClient.CreateTextToVideoGeneration.g.cs
@@ -23,7 +23,7 @@ namespace Leonardo
         /// The prompt used to generate video
         /// </param>
         /// <param name="resolution">
-        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720.<br/>
+        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
         /// Default Value: RESOLUTION_480
         /// </param>
         /// <param name="model">

--- a/src/libs/Leonardo/Generated/Leonardo.Models.CreateImageToVideoGenerationRequest.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.CreateImageToVideoGenerationRequest.g.cs
@@ -31,7 +31,7 @@ namespace Leonardo
         public required global::Leonardo.CreateImageToVideoGenerationRequestImageType ImageType { get; set; }
 
         /// <summary>
-        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified.<br/>
+        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
         /// Default Value: RESOLUTION_480
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("resolution")]
@@ -101,7 +101,7 @@ namespace Leonardo
         /// Type indicating whether the init image is uploaded or generated. Use only image or imageId with imageType.
         /// </param>
         /// <param name="resolution">
-        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified.<br/>
+        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
         /// Default Value: RESOLUTION_480
         /// </param>
         /// <param name="model">

--- a/src/libs/Leonardo/Generated/Leonardo.Models.CreateImageToVideoGenerationRequestResolution.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.CreateImageToVideoGenerationRequestResolution.g.cs
@@ -4,7 +4,7 @@
 namespace Leonardo
 {
     /// <summary>
-    /// The resolution of the video. Defaults to RESOLUTION_480 if not specified.<br/>
+    /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
     /// Default Value: RESOLUTION_480
     /// </summary>
     public enum CreateImageToVideoGenerationRequestResolution
@@ -17,6 +17,10 @@ namespace Leonardo
         /// 
         /// </summary>
         RESOLUTION720,
+        /// <summary>
+        /// 
+        /// </summary>
+        RESOLUTION1080,
     }
 
     /// <summary>
@@ -33,6 +37,7 @@ namespace Leonardo
             {
                 CreateImageToVideoGenerationRequestResolution.RESOLUTION480 => "RESOLUTION_480",
                 CreateImageToVideoGenerationRequestResolution.RESOLUTION720 => "RESOLUTION_720",
+                CreateImageToVideoGenerationRequestResolution.RESOLUTION1080 => "RESOLUTION_1080",
                 _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
             };
         }
@@ -45,6 +50,7 @@ namespace Leonardo
             {
                 "RESOLUTION_480" => CreateImageToVideoGenerationRequestResolution.RESOLUTION480,
                 "RESOLUTION_720" => CreateImageToVideoGenerationRequestResolution.RESOLUTION720,
+                "RESOLUTION_1080" => CreateImageToVideoGenerationRequestResolution.RESOLUTION1080,
                 _ => null,
             };
         }

--- a/src/libs/Leonardo/Generated/Leonardo.Models.CreateTextToVideoGenerationRequest.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.CreateTextToVideoGenerationRequest.g.cs
@@ -16,7 +16,7 @@ namespace Leonardo
         public required string Prompt { get; set; }
 
         /// <summary>
-        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720.<br/>
+        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
         /// Default Value: RESOLUTION_480
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("resolution")]
@@ -94,7 +94,7 @@ namespace Leonardo
         /// The prompt used to generate video
         /// </param>
         /// <param name="resolution">
-        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720.<br/>
+        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
         /// Default Value: RESOLUTION_480
         /// </param>
         /// <param name="model">

--- a/src/libs/Leonardo/Generated/Leonardo.Models.CreateTextToVideoGenerationRequestResolution.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.CreateTextToVideoGenerationRequestResolution.g.cs
@@ -4,7 +4,7 @@
 namespace Leonardo
 {
     /// <summary>
-    /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720.<br/>
+    /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
     /// Default Value: RESOLUTION_480
     /// </summary>
     public enum CreateTextToVideoGenerationRequestResolution
@@ -17,6 +17,10 @@ namespace Leonardo
         /// 
         /// </summary>
         RESOLUTION720,
+        /// <summary>
+        /// 
+        /// </summary>
+        RESOLUTION1080,
     }
 
     /// <summary>
@@ -33,6 +37,7 @@ namespace Leonardo
             {
                 CreateTextToVideoGenerationRequestResolution.RESOLUTION480 => "RESOLUTION_480",
                 CreateTextToVideoGenerationRequestResolution.RESOLUTION720 => "RESOLUTION_720",
+                CreateTextToVideoGenerationRequestResolution.RESOLUTION1080 => "RESOLUTION_1080",
                 _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
             };
         }
@@ -45,6 +50,7 @@ namespace Leonardo
             {
                 "RESOLUTION_480" => CreateTextToVideoGenerationRequestResolution.RESOLUTION480,
                 "RESOLUTION_720" => CreateTextToVideoGenerationRequestResolution.RESOLUTION720,
+                "RESOLUTION_1080" => CreateTextToVideoGenerationRequestResolution.RESOLUTION1080,
                 _ => null,
             };
         }

--- a/src/libs/Leonardo/Generated/Leonardo.MotionClient.CreateImageToVideoGeneration.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.MotionClient.CreateImageToVideoGeneration.g.cs
@@ -180,7 +180,7 @@ namespace Leonardo
         /// Type indicating whether the init image is uploaded or generated. Use only image or imageId with imageType.
         /// </param>
         /// <param name="resolution">
-        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified.<br/>
+        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
         /// Default Value: RESOLUTION_480
         /// </param>
         /// <param name="model">

--- a/src/libs/Leonardo/Generated/Leonardo.MotionClient.CreateTextToVideoGeneration.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.MotionClient.CreateTextToVideoGeneration.g.cs
@@ -174,7 +174,7 @@ namespace Leonardo
         /// The prompt used to generate video
         /// </param>
         /// <param name="resolution">
-        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720.<br/>
+        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
         /// Default Value: RESOLUTION_480
         /// </param>
         /// <param name="model">

--- a/src/libs/Leonardo/openapi.yaml
+++ b/src/libs/Leonardo/openapi.yaml
@@ -849,7 +849,8 @@ paths:
                   enum:
                     - RESOLUTION_480
                     - RESOLUTION_720
-                  description: The resolution of the video. Defaults to RESOLUTION_480 if not specified.
+                    - RESOLUTION_1080
+                  description: The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.
                   default: RESOLUTION_480
                   nullable: true
                 model:
@@ -934,7 +935,8 @@ paths:
                   enum:
                     - RESOLUTION_480
                     - RESOLUTION_720
-                  description: The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720.
+                    - RESOLUTION_1080
+                  description: The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.
                   default: RESOLUTION_480
                   nullable: true
                 model:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for 1080p resolution in image-to-video and text-to-video generation endpoints.

* **Documentation**
  * Updated descriptions to clarify that the VEO3 model now supports both 720p and 1080p resolutions, with 480p remaining as the default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->