### PR TITLE
feat:Add optional isVideo boolean to /prompt/improve POST request schema

### DIFF
--- a/src/libs/Leonardo/Generated/Leonardo.IPromptClient.PromptImprove.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.IPromptClient.PromptImprove.g.cs
@@ -25,11 +25,16 @@ namespace Leonardo
         /// <param name="promptInstructions">
         /// The prompt is improved based on the given instructions.
         /// </param>
+        /// <param name="isVideo">
+        /// Specifies whether the prompt is for a video generation. Defaults to false (image prompt).<br/>
+        /// Example: true
+        /// </param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         global::System.Threading.Tasks.Task<global::Leonardo.PromptImproveResponse> PromptImproveAsync(
             string prompt,
             string? promptInstructions = default,
+            bool? isVideo = default,
             global::System.Threading.CancellationToken cancellationToken = default);
     }
 }

--- a/src/libs/Leonardo/Generated/Leonardo.Models.PromptImproveRequest.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.PromptImproveRequest.g.cs
@@ -22,6 +22,14 @@ namespace Leonardo
         public string? PromptInstructions { get; set; }
 
         /// <summary>
+        /// Specifies whether the prompt is for a video generation. Defaults to false (image prompt).<br/>
+        /// Example: true
+        /// </summary>
+        /// <example>true</example>
+        [global::System.Text.Json.Serialization.JsonPropertyName("isVideo")]
+        public bool? IsVideo { get; set; }
+
+        /// <summary>
         /// Additional properties that are not explicitly defined in the schema
         /// </summary>
         [global::System.Text.Json.Serialization.JsonExtensionData]
@@ -36,15 +44,21 @@ namespace Leonardo
         /// <param name="promptInstructions">
         /// The prompt is improved based on the given instructions.
         /// </param>
+        /// <param name="isVideo">
+        /// Specifies whether the prompt is for a video generation. Defaults to false (image prompt).<br/>
+        /// Example: true
+        /// </param>
 #if NET7_0_OR_GREATER
         [global::System.Diagnostics.CodeAnalysis.SetsRequiredMembers]
 #endif
         public PromptImproveRequest(
             string prompt,
-            string? promptInstructions)
+            string? promptInstructions,
+            bool? isVideo)
         {
             this.Prompt = prompt ?? throw new global::System.ArgumentNullException(nameof(prompt));
             this.PromptInstructions = promptInstructions;
+            this.IsVideo = isVideo;
         }
 
         /// <summary>

--- a/src/libs/Leonardo/Generated/Leonardo.PromptClient.PromptImprove.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.PromptClient.PromptImprove.g.cs
@@ -176,17 +176,23 @@ namespace Leonardo
         /// <param name="promptInstructions">
         /// The prompt is improved based on the given instructions.
         /// </param>
+        /// <param name="isVideo">
+        /// Specifies whether the prompt is for a video generation. Defaults to false (image prompt).<br/>
+        /// Example: true
+        /// </param>
         /// <param name="cancellationToken">The token to cancel the operation with</param>
         /// <exception cref="global::System.InvalidOperationException"></exception>
         public async global::System.Threading.Tasks.Task<global::Leonardo.PromptImproveResponse> PromptImproveAsync(
             string prompt,
             string? promptInstructions = default,
+            bool? isVideo = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             var __request = new global::Leonardo.PromptImproveRequest
             {
                 Prompt = prompt,
                 PromptInstructions = promptInstructions,
+                IsVideo = isVideo,
             };
 
             return await PromptImproveAsync(

--- a/src/libs/Leonardo/openapi.yaml
+++ b/src/libs/Leonardo/openapi.yaml
@@ -3171,6 +3171,11 @@ paths:
                   type: string
                   description: The prompt is improved based on the given instructions.
                   nullable: true
+                isVideo:
+                  type: boolean
+                  description: Specifies whether the prompt is for a video generation. Defaults to false (image prompt).
+                  nullable: true
+                  example: true
         required: true
       responses:
         '200':


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying if a prompt is intended for video generation when using the prompt improvement feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->