### PR TITLE
feat:Add MOTION2FAST/VEO3FAST; per-model resolutions; remove 480 default

### DIFF
--- a/src/libs/Leonardo/Generated/Leonardo.IMotionClient.CreateImageToVideoGeneration.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.IMotionClient.CreateImageToVideoGeneration.g.cs
@@ -29,8 +29,7 @@ namespace Leonardo
         /// Type indicating whether the init image is uploaded or generated. Use only image or imageId with imageType.
         /// </param>
         /// <param name="resolution">
-        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
-        /// Default Value: RESOLUTION_480
+        /// The resolution of the video. MOTION2 and MOTION2FAST supports RESOLUTION_480 and RESOLUTION_720 and defaults to RESOLUTION_480 if not specified. VEO3 and VEO3FAST supports RESOLUTION_720 and RESOLUTION_1080 and defaults to RESOLUTION_720 if not specified.
         /// </param>
         /// <param name="model">
         /// The model to use for the video generation. Defaults to MOTION2 if not specified.<br/>

--- a/src/libs/Leonardo/Generated/Leonardo.IMotionClient.CreateTextToVideoGeneration.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.IMotionClient.CreateTextToVideoGeneration.g.cs
@@ -23,8 +23,7 @@ namespace Leonardo
         /// The prompt used to generate video
         /// </param>
         /// <param name="resolution">
-        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
-        /// Default Value: RESOLUTION_480
+        /// The resolution of the video. MOTION2 and MOTION2FAST supports RESOLUTION_480 and RESOLUTION_720 and defaults to RESOLUTION_480 if not specified. VEO3 and VEO3FAST supports RESOLUTION_720 and RESOLUTION_1080 and defaults to RESOLUTION_720 if not specified.
         /// </param>
         /// <param name="model">
         /// The model to use for the video generation. Defaults to MOTION2 if not specified.<br/>

--- a/src/libs/Leonardo/Generated/Leonardo.Models.CreateImageToVideoGenerationRequest.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.CreateImageToVideoGenerationRequest.g.cs
@@ -31,8 +31,7 @@ namespace Leonardo
         public required global::Leonardo.CreateImageToVideoGenerationRequestImageType ImageType { get; set; }
 
         /// <summary>
-        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
-        /// Default Value: RESOLUTION_480
+        /// The resolution of the video. MOTION2 and MOTION2FAST supports RESOLUTION_480 and RESOLUTION_720 and defaults to RESOLUTION_480 if not specified. VEO3 and VEO3FAST supports RESOLUTION_720 and RESOLUTION_1080 and defaults to RESOLUTION_720 if not specified.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("resolution")]
         [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Leonardo.JsonConverters.CreateImageToVideoGenerationRequestResolutionJsonConverter))]
@@ -113,8 +112,7 @@ namespace Leonardo
         /// Type indicating whether the init image is uploaded or generated. Use only image or imageId with imageType.
         /// </param>
         /// <param name="resolution">
-        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
-        /// Default Value: RESOLUTION_480
+        /// The resolution of the video. MOTION2 and MOTION2FAST supports RESOLUTION_480 and RESOLUTION_720 and defaults to RESOLUTION_480 if not specified. VEO3 and VEO3FAST supports RESOLUTION_720 and RESOLUTION_1080 and defaults to RESOLUTION_720 if not specified.
         /// </param>
         /// <param name="model">
         /// The model to use for the video generation. Defaults to MOTION2 if not specified.<br/>

--- a/src/libs/Leonardo/Generated/Leonardo.Models.CreateImageToVideoGenerationRequestModel.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.CreateImageToVideoGenerationRequestModel.g.cs
@@ -17,6 +17,14 @@ namespace Leonardo
         /// 
         /// </summary>
         VEO3,
+        /// <summary>
+        /// 
+        /// </summary>
+        MOTION2FAST,
+        /// <summary>
+        /// 
+        /// </summary>
+        VEO3FAST,
     }
 
     /// <summary>
@@ -33,6 +41,8 @@ namespace Leonardo
             {
                 CreateImageToVideoGenerationRequestModel.MOTION2 => "MOTION2",
                 CreateImageToVideoGenerationRequestModel.VEO3 => "VEO3",
+                CreateImageToVideoGenerationRequestModel.MOTION2FAST => "MOTION2FAST",
+                CreateImageToVideoGenerationRequestModel.VEO3FAST => "VEO3FAST",
                 _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
             };
         }
@@ -45,6 +55,8 @@ namespace Leonardo
             {
                 "MOTION2" => CreateImageToVideoGenerationRequestModel.MOTION2,
                 "VEO3" => CreateImageToVideoGenerationRequestModel.VEO3,
+                "MOTION2FAST" => CreateImageToVideoGenerationRequestModel.MOTION2FAST,
+                "VEO3FAST" => CreateImageToVideoGenerationRequestModel.VEO3FAST,
                 _ => null,
             };
         }

--- a/src/libs/Leonardo/Generated/Leonardo.Models.CreateImageToVideoGenerationRequestResolution.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.CreateImageToVideoGenerationRequestResolution.g.cs
@@ -4,8 +4,7 @@
 namespace Leonardo
 {
     /// <summary>
-    /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
-    /// Default Value: RESOLUTION_480
+    /// The resolution of the video. MOTION2 and MOTION2FAST supports RESOLUTION_480 and RESOLUTION_720 and defaults to RESOLUTION_480 if not specified. VEO3 and VEO3FAST supports RESOLUTION_720 and RESOLUTION_1080 and defaults to RESOLUTION_720 if not specified.
     /// </summary>
     public enum CreateImageToVideoGenerationRequestResolution
     {

--- a/src/libs/Leonardo/Generated/Leonardo.Models.CreateTextToVideoGenerationRequest.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.CreateTextToVideoGenerationRequest.g.cs
@@ -16,8 +16,7 @@ namespace Leonardo
         public required string Prompt { get; set; }
 
         /// <summary>
-        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
-        /// Default Value: RESOLUTION_480
+        /// The resolution of the video. MOTION2 and MOTION2FAST supports RESOLUTION_480 and RESOLUTION_720 and defaults to RESOLUTION_480 if not specified. VEO3 and VEO3FAST supports RESOLUTION_720 and RESOLUTION_1080 and defaults to RESOLUTION_720 if not specified.
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("resolution")]
         [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Leonardo.JsonConverters.CreateTextToVideoGenerationRequestResolutionJsonConverter))]
@@ -106,8 +105,7 @@ namespace Leonardo
         /// The prompt used to generate video
         /// </param>
         /// <param name="resolution">
-        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
-        /// Default Value: RESOLUTION_480
+        /// The resolution of the video. MOTION2 and MOTION2FAST supports RESOLUTION_480 and RESOLUTION_720 and defaults to RESOLUTION_480 if not specified. VEO3 and VEO3FAST supports RESOLUTION_720 and RESOLUTION_1080 and defaults to RESOLUTION_720 if not specified.
         /// </param>
         /// <param name="model">
         /// The model to use for the video generation. Defaults to MOTION2 if not specified.<br/>

--- a/src/libs/Leonardo/Generated/Leonardo.Models.CreateTextToVideoGenerationRequestModel.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.CreateTextToVideoGenerationRequestModel.g.cs
@@ -17,6 +17,14 @@ namespace Leonardo
         /// 
         /// </summary>
         VEO3,
+        /// <summary>
+        /// 
+        /// </summary>
+        MOTION2FAST,
+        /// <summary>
+        /// 
+        /// </summary>
+        VEO3FAST,
     }
 
     /// <summary>
@@ -33,6 +41,8 @@ namespace Leonardo
             {
                 CreateTextToVideoGenerationRequestModel.MOTION2 => "MOTION2",
                 CreateTextToVideoGenerationRequestModel.VEO3 => "VEO3",
+                CreateTextToVideoGenerationRequestModel.MOTION2FAST => "MOTION2FAST",
+                CreateTextToVideoGenerationRequestModel.VEO3FAST => "VEO3FAST",
                 _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
             };
         }
@@ -45,6 +55,8 @@ namespace Leonardo
             {
                 "MOTION2" => CreateTextToVideoGenerationRequestModel.MOTION2,
                 "VEO3" => CreateTextToVideoGenerationRequestModel.VEO3,
+                "MOTION2FAST" => CreateTextToVideoGenerationRequestModel.MOTION2FAST,
+                "VEO3FAST" => CreateTextToVideoGenerationRequestModel.VEO3FAST,
                 _ => null,
             };
         }

--- a/src/libs/Leonardo/Generated/Leonardo.Models.CreateTextToVideoGenerationRequestResolution.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.Models.CreateTextToVideoGenerationRequestResolution.g.cs
@@ -4,8 +4,7 @@
 namespace Leonardo
 {
     /// <summary>
-    /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
-    /// Default Value: RESOLUTION_480
+    /// The resolution of the video. MOTION2 and MOTION2FAST supports RESOLUTION_480 and RESOLUTION_720 and defaults to RESOLUTION_480 if not specified. VEO3 and VEO3FAST supports RESOLUTION_720 and RESOLUTION_1080 and defaults to RESOLUTION_720 if not specified.
     /// </summary>
     public enum CreateTextToVideoGenerationRequestResolution
     {

--- a/src/libs/Leonardo/Generated/Leonardo.MotionClient.CreateImageToVideoGeneration.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.MotionClient.CreateImageToVideoGeneration.g.cs
@@ -180,8 +180,7 @@ namespace Leonardo
         /// Type indicating whether the init image is uploaded or generated. Use only image or imageId with imageType.
         /// </param>
         /// <param name="resolution">
-        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
-        /// Default Value: RESOLUTION_480
+        /// The resolution of the video. MOTION2 and MOTION2FAST supports RESOLUTION_480 and RESOLUTION_720 and defaults to RESOLUTION_480 if not specified. VEO3 and VEO3FAST supports RESOLUTION_720 and RESOLUTION_1080 and defaults to RESOLUTION_720 if not specified.
         /// </param>
         /// <param name="model">
         /// The model to use for the video generation. Defaults to MOTION2 if not specified.<br/>

--- a/src/libs/Leonardo/Generated/Leonardo.MotionClient.CreateTextToVideoGeneration.g.cs
+++ b/src/libs/Leonardo/Generated/Leonardo.MotionClient.CreateTextToVideoGeneration.g.cs
@@ -174,8 +174,7 @@ namespace Leonardo
         /// The prompt used to generate video
         /// </param>
         /// <param name="resolution">
-        /// The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.<br/>
-        /// Default Value: RESOLUTION_480
+        /// The resolution of the video. MOTION2 and MOTION2FAST supports RESOLUTION_480 and RESOLUTION_720 and defaults to RESOLUTION_480 if not specified. VEO3 and VEO3FAST supports RESOLUTION_720 and RESOLUTION_1080 and defaults to RESOLUTION_720 if not specified.
         /// </param>
         /// <param name="model">
         /// The model to use for the video generation. Defaults to MOTION2 if not specified.<br/>

--- a/src/libs/Leonardo/openapi.yaml
+++ b/src/libs/Leonardo/openapi.yaml
@@ -850,14 +850,15 @@ paths:
                     - RESOLUTION_480
                     - RESOLUTION_720
                     - RESOLUTION_1080
-                  description: The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.
-                  default: RESOLUTION_480
+                  description: The resolution of the video. MOTION2 and MOTION2FAST supports RESOLUTION_480 and RESOLUTION_720 and defaults to RESOLUTION_480 if not specified. VEO3 and VEO3FAST supports RESOLUTION_720 and RESOLUTION_1080 and defaults to RESOLUTION_720 if not specified.
                   nullable: true
                 model:
                   title: String
                   enum:
                     - MOTION2
                     - VEO3
+                    - MOTION2FAST
+                    - VEO3FAST
                   description: The model to use for the video generation. Defaults to MOTION2 if not specified.
                   default: MOTION2
                   nullable: true
@@ -946,14 +947,15 @@ paths:
                     - RESOLUTION_480
                     - RESOLUTION_720
                     - RESOLUTION_1080
-                  description: The resolution of the video. Defaults to RESOLUTION_480 if not specified. VEO3 only supports RESOLUTION_720 and RESOLUTION_1080.
-                  default: RESOLUTION_480
+                  description: The resolution of the video. MOTION2 and MOTION2FAST supports RESOLUTION_480 and RESOLUTION_720 and defaults to RESOLUTION_480 if not specified. VEO3 and VEO3FAST supports RESOLUTION_720 and RESOLUTION_1080 and defaults to RESOLUTION_720 if not specified.
                   nullable: true
                 model:
                   title: String
                   enum:
                     - MOTION2
                     - VEO3
+                    - MOTION2FAST
+                    - VEO3FAST
                   description: The model to use for the video generation. Defaults to MOTION2 if not specified.
                   default: MOTION2
                   nullable: true


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for MOTION2FAST and VEO3FAST models in image-to-video and text-to-video generation.
* **Documentation**
  * Updated resolution options to reflect per-model availability and defaults:
    * MOTION2/MOTION2FAST: 480 or 720 (default 480).
    * VEO3/VEO3FAST: 720 or 1080 (default 720).
  * Removed references to a single global default resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->